### PR TITLE
Enable Github installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "NODE_ENV=test && yarn run format:check && tape -r ts-node/register tests/**/*.ts | tap-diff",
     "build": "tsc && chmod 775 lib/cli.js",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "format": "tslint --fix --project ./tsconfig.json && prettier --write src/**/*.ts",
     "format:check": "prettier --list-different src/**/*.ts"
   },


### PR DESCRIPTION
Change "prepublishOnly" script to "prepare", which also runs during git installs. Fixes #78.