### PR TITLE
Support for namespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
   "license": "MIT",
   "dependencies": {
     "@ts-morph/common": "^0.6.0",
-    "@types/command-line-args": "^5.0.0",
-    "@types/command-line-usage": "^5.0.1",
-    "@types/lodash": "^4.14.160",
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.0",
     "lodash": "^4.17.20",
@@ -30,6 +27,9 @@
     "typescript": "^3.5.3"
   },
   "devDependencies": {
+    "@types/command-line-args": "^5.0.0",
+    "@types/command-line-usage": "^5.0.1",
+    "@types/lodash": "^4.14.160",
     "@types/node": "^14.6.0",
     "@types/tape": "^4.2.32",
     "@types/uglify-js": "^3.0.3",


### PR DESCRIPTION
Resolve #96 
```
export namespace iTest {
  /** @see {isTestT1} ts-auto-guard:type-guard */
  export interface T1 {
    key: string;
  }
}
```
will produce this code
```
/*
 * Generated type guards for "test.ts".
 * WARNING: Do not manually change this file.
 */
import { iTest } from "./test";

export function isTestT1(obj: any, _argumentName?: string): obj is iTest.T1 {
    return (
        typeof obj === "object" &&
        typeof obj.key === "string"
    )
}
```