### PR TITLE
Add --import-guards option for cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ export function isPerson(obj: any): obj is Person {
 Using the `shortcircuit` option in combination with [uglify-js's `dead_code` and `global_defs` options](https://github.com/mishoo/UglifyJS2#compress-options) will let you omit the long and complicated checks from your production code.
 
 ## Add Import to Source File
-ts-auto-guard supports an `ìmport-guards` flag. This flag will add an import statement at the top of the source files for the generated type guards. The flag also optionally a custom name for the import alias, if none is passed then `TypeGuards` is used as a default.
+ts-auto-guard supports an `ìmport-guards` flag. This flag will add an import statement at the top and a named export at the bottom of the source files for the generated type guards. The `ìmport-guards` flag also optionally accepts a custom name for the import alias, if none is passed then `TypeGuards` is used as a default.
 
-If you would also like to export the type guards from that same file use the `export-guards` flag with the `import-guards` flag.
+If you would like to override the default behavior and not have the type guards exported from source use the `prevent-export-imported` flag with the `import-guards` flag.
 
 
 ```
-$ ts-auto-guard --import-guards="Guards" --export-guards
+$ ts-auto-guard --import-guards="Guards"
 ```
 
 Will result in the following being added to your source code.

--- a/README.md
+++ b/README.md
@@ -130,3 +130,24 @@ export function isPerson(obj: any): obj is Person {
 ```
 
 Using the `shortcircuit` option in combination with [uglify-js's `dead_code` and `global_defs` options](https://github.com/mishoo/UglifyJS2#compress-options) will let you omit the long and complicated checks from your production code.
+
+## Add Import to Source File
+ts-auto-guard supports an `ìmport-guards` flag. This flag will add an import statement at the top of the source files for the generated type guards. The flag also optionally a custom name for the import alias, if none is passed then `TypeGuards` is used as a default.
+
+If you would also like to export the type guards from that same file use the `export-guards` flag with the `import-guards` flag.
+
+
+```
+$ ts-auto-guard --import-guards="Guards" --export-guards
+```
+
+Will result in the following being added to your source code.
+```ts
+// my-project/Person.ts
+
+import * as Guards from './Person.guard'
+
+/** The rest of your source code */
+
+export { Guards }
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,8 +41,7 @@ const optionList = [
     type: Boolean,
   },
   {
-    description:
-      'Adds im',
+    description: 'Adds TypeGuard import and export to source file',
     name: 'import-guards',
     type: Boolean,
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ interface ICliOptions {
   help: boolean
   debug: boolean
   'export-all': boolean
+  'import-guards': boolean
 }
 
 const optionList = [
@@ -37,6 +38,12 @@ const optionList = [
     description:
       'Generate checks for all exported types, even those not marked with comment',
     name: 'export-all',
+    type: Boolean,
+  },
+  {
+    description:
+      'Adds im',
+    name: 'import-guards',
     type: Boolean,
   },
   {
@@ -76,6 +83,7 @@ async function run() {
       processOptions: {
         debug: options.debug,
         exportAll: options['export-all'],
+        importGuards: options['import-guards'],
         shortCircuitCondition: options.shortcircuit,
       },
       project,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,8 @@ interface ICliOptions {
   help: boolean
   debug: boolean
   'export-all': boolean
-  'import-guards': boolean
+  'import-guards': string
+  'export-guards': boolean
 }
 
 const optionList = [
@@ -41,8 +42,16 @@ const optionList = [
     type: Boolean,
   },
   {
-    description: 'Adds TypeGuard import and export to source file',
+    description:
+      'Adds TypeGuard import to source file, to also export TypeGuard from source use with --import-guards. Optionally accepts a string to choose custom import alias.',
     name: 'import-guards',
+    typeLabel: '{underline TypeGuard}',
+    type: String,
+  },
+  {
+    description:
+      'Exports TypeGuard from source file, requires --import-guards to work.',
+    name: 'export-guards',
     type: Boolean,
   },
   {
@@ -76,6 +85,19 @@ async function run() {
     console.error('Could not find tsconfig')
     return
   }
+  if ('import-guards' in options) {
+    /** Checks if valid name passed as argument or replace with default if empty */
+    if (!options['import-guards']) {
+      options['import-guards'] = 'TypeGuards'
+    }
+    try {
+      eval(`const ${options['import-guards']} = true`)
+    } catch (error) {
+      console.log('Please pass a valid import alias')
+      throw error
+    }
+  }
+
   try {
     await generate({
       paths: options.paths,
@@ -83,6 +105,7 @@ async function run() {
         debug: options.debug,
         exportAll: options['export-all'],
         importGuards: options['import-guards'],
+        exportGuards: options['export-guards'],
         shortCircuitCondition: options.shortcircuit,
       },
       project,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ interface ICliOptions {
   debug: boolean
   'export-all': boolean
   'import-guards': string
-  'export-guards': boolean
+  'prevent-export-imported': boolean
 }
 
 const optionList = [
@@ -50,8 +50,8 @@ const optionList = [
   },
   {
     description:
-      'Exports TypeGuard from source file, requires --import-guards to work.',
-    name: 'export-guards',
+      'Overrides the default behavior for --import-guards by skipping export from source.',
+    name: 'prevent-export-imported',
     type: Boolean,
   },
   {
@@ -105,7 +105,7 @@ async function run() {
         debug: options.debug,
         exportAll: options['export-all'],
         importGuards: options['import-guards'],
-        exportGuards: options['export-guards'],
+        preventExportImported: options['prevent-export-imported'],
         shortCircuitCondition: options.shortcircuit,
       },
       project,

--- a/src/index.ts
+++ b/src/index.ts
@@ -679,7 +679,7 @@ function createAddDependency(dependencies: Dependencies): IAddDependency {
 }
 
 export interface IProcessOptions {
-  exportAll?: boolean,
+  exportAll?: boolean
   importGuards?: boolean
   shortCircuitCondition?: string
   debug?: boolean
@@ -835,16 +835,28 @@ export function processProject(
       )
       if (options.importGuards) {
         const relativeOutPath =
-          './' + outFile.getFilePath().split('/').reverse()[0].replace(/\.(ts|tsx|d\.ts)$/, '')
+          './' +
+          outFile
+            .getFilePath()
+            .split('/')
+            .reverse()[0]
+            .replace(/\.(ts|tsx|d\.ts)$/, '')
         const importStatement = `import * as TypeGuards from "${relativeOutPath}";\n`
         const exportStatement = `export { TypeGuards };`
-        const { hasImport, hasExport, statements } = sourceFile.getStatements().reduce((reduced, node) => {
-          const nodeText = node.getText().replace(/\s{2,}/g, ' ')
-          reduced.hasImport ||= nodeText.includes('import * as TypeGuards')
-          reduced.hasExport ||= nodeText.includes('export { TypeGuards }')
-          reduced.statements += 1
-          return reduced;
-        }, {hasImport: false, hasExport: false, statements: 0})
+        const {
+          hasImport,
+          hasExport,
+          statements,
+        } = sourceFile.getStatements().reduce(
+          (reduced, node) => {
+            const nodeText = node.getText().replace(/\s{2,}/g, ' ')
+            reduced.hasImport ||= nodeText.includes('import * as TypeGuards')
+            reduced.hasExport ||= nodeText.includes('export { TypeGuards }')
+            reduced.statements += 1
+            return reduced
+          },
+          { hasImport: false, hasExport: false, statements: 0 }
+        )
         if (!hasImport) {
           sourceFile.insertStatements(0, importStatement)
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -842,7 +842,7 @@ export function processProject(
             .split('/')
             .reverse()[0]
             .replace(/\.(ts|tsx|d\.ts)$/, '')
-        const importStatement = `import * as ${options.importGuards} from "${relativeOutPath}";\n`
+        const importStatement = `import * as ${options.importGuards} from "${relativeOutPath}";`
         const exportStatement = `export { ${options.importGuards} };`
         const {
           hasImport,
@@ -866,7 +866,10 @@ export function processProject(
           sourceFile.insertStatements(0, importStatement)
         }
         if (!hasExport && options.exportGuards) {
-          sourceFile.insertStatements(statements, exportStatement)
+          sourceFile.insertStatements(
+            !hasImport ? statements + 1 : statements,
+            exportStatement
+          )
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -680,7 +680,8 @@ function createAddDependency(dependencies: Dependencies): IAddDependency {
 
 export interface IProcessOptions {
   exportAll?: boolean
-  importGuards?: boolean
+  importGuards?: string
+  exportGuards?: boolean
   shortCircuitCondition?: string
   debug?: boolean
 }
@@ -841,8 +842,8 @@ export function processProject(
             .split('/')
             .reverse()[0]
             .replace(/\.(ts|tsx|d\.ts)$/, '')
-        const importStatement = `import * as TypeGuards from "${relativeOutPath}";\n`
-        const exportStatement = `export { TypeGuards };`
+        const importStatement = `import * as ${options.importGuards} from "${relativeOutPath}";\n`
+        const exportStatement = `export { ${options.importGuards} };`
         const {
           hasImport,
           hasExport,
@@ -850,8 +851,8 @@ export function processProject(
         } = sourceFile.getStatements().reduce(
           (reduced, node) => {
             const nodeText = node.getText().replace(/\s{2,}/g, ' ')
-            reduced.hasImport ||= nodeText.includes('import * as TypeGuards')
-            reduced.hasExport ||= nodeText.includes('export { TypeGuards }')
+            reduced.hasImport ||= nodeText.includes(`import * as ${options.importGuards}`)
+            reduced.hasExport ||= nodeText.includes(`export { ${options.importGuards} }`)
             reduced.statements += 1
             return reduced
           },
@@ -860,7 +861,7 @@ export function processProject(
         if (!hasImport) {
           sourceFile.insertStatements(0, importStatement)
         }
-        if (!hasExport) {
+        if (!hasExport && options.exportGuards) {
           sourceFile.insertStatements(statements, exportStatement)
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -843,7 +843,7 @@ export function processProject(
             .reverse()[0]
             .replace(/\.(ts|tsx|d\.ts)$/, '')
         const importStatement = `import * as ${options.importGuards} from "${relativeOutPath}";`
-        const exportStatement = `\nexport { ${options.importGuards} };`
+        const exportStatement = `export { ${options.importGuards} };`
         const {
           hasImport,
           hasExport,
@@ -871,7 +871,6 @@ export function processProject(
             exportStatement
           )
         }
-        sourceFile.formatText()
       }
 
       outFile.formatText()

--- a/src/index.ts
+++ b/src/index.ts
@@ -843,7 +843,7 @@ export function processProject(
             .reverse()[0]
             .replace(/\.(ts|tsx|d\.ts)$/, '')
         const importStatement = `import * as ${options.importGuards} from "${relativeOutPath}";`
-        const exportStatement = `export { ${options.importGuards} };`
+        const exportStatement = `\nexport { ${options.importGuards} };`
         const {
           hasImport,
           hasExport,
@@ -871,6 +871,7 @@ export function processProject(
             exportStatement
           )
         }
+        sourceFile.formatText()
       }
 
       outFile.formatText()

--- a/src/index.ts
+++ b/src/index.ts
@@ -851,8 +851,12 @@ export function processProject(
         } = sourceFile.getStatements().reduce(
           (reduced, node) => {
             const nodeText = node.getText().replace(/\s{2,}/g, ' ')
-            reduced.hasImport ||= nodeText.includes(`import * as ${options.importGuards}`)
-            reduced.hasExport ||= nodeText.includes(`export { ${options.importGuards} }`)
+            reduced.hasImport ||= nodeText.includes(
+              `import * as ${options.importGuards}`
+            )
+            reduced.hasExport ||= nodeText.includes(
+              `export { ${options.importGuards} }`
+            )
             reduced.statements += 1
             return reduced
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -679,7 +679,8 @@ function createAddDependency(dependencies: Dependencies): IAddDependency {
 }
 
 export interface IProcessOptions {
-  exportAll?: boolean
+  exportAll?: boolean,
+  importGuards?: boolean
   shortCircuitCondition?: string
   debug?: boolean
 }
@@ -832,6 +833,25 @@ export function processProject(
           ` */`,
         ].join('\n')
       )
+      if (options.importGuards) {
+        const relativeOutPath =
+          './' + outFile.getFilePath().split('/').reverse()[0].replace(/\.(ts|tsx|d\.ts)$/, '')
+        const importStatement = `import * as TypeGuards from "${relativeOutPath}";\n`
+        const exportStatement = `export { TypeGuards };`
+        const { hasImport, hasExport, statements } = sourceFile.getStatements().reduce((reduced, node) => {
+          const nodeText = node.getText().replace(/\s{2,}/g, ' ')
+          reduced.hasImport ||= nodeText.includes('import * as TypeGuards')
+          reduced.hasExport ||= nodeText.includes('export { TypeGuards }')
+          reduced.statements += 1
+          return reduced;
+        }, {hasImport: false, hasExport: false, statements: 0})
+        if (!hasImport) {
+          sourceFile.insertStatements(0, importStatement)
+        }
+        if (!hasExport) {
+          sourceFile.insertStatements(statements, exportStatement)
+        }
+      }
 
       outFile.formatText()
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -681,7 +681,7 @@ function createAddDependency(dependencies: Dependencies): IAddDependency {
 export interface IProcessOptions {
   exportAll?: boolean
   importGuards?: string
-  exportGuards?: boolean
+  preventExportImported?: boolean
   shortCircuitCondition?: string
   debug?: boolean
 }
@@ -865,7 +865,7 @@ export function processProject(
         if (!hasImport) {
           sourceFile.insertStatements(0, importStatement)
         }
-        if (!hasExport && options.exportGuards) {
+        if (!hasExport && !options.preventExportImported) {
           sourceFile.insertStatements(
             !hasImport ? statements + 1 : statements,
             exportStatement

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -832,5 +832,5 @@ testProcessProject(
            )
     }`,
   },
-  { options: { importGuards: 'CustomGuardAlias', exportGuards: true } }
+  { options: { importGuards: 'CustomGuardAlias' } }
 )

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -822,6 +822,7 @@ export interface Empty { }
   {
     'test.ts': `
     import * as CustomGuardAlias from "./test.guard";
+
     /** @see {isEmpty} ts-auto-guard:type-guard */
     export interface Empty {}
     export { CustomGuardAlias };`,

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -822,10 +822,8 @@ export interface Empty { }
   {
     'test.ts': `
     import * as CustomGuardAlias from "./test.guard";
-
     /** @see {isEmpty} ts-auto-guard:type-guard */
     export interface Empty {}
-
     export { CustomGuardAlias };`,
     'test.guard.ts': `
     import { Empty } from "./test";
@@ -838,32 +836,5 @@ export interface Empty { }
            )
     }`,
   },
-  { options: { importGuards: 'CustomGuardAlias'} }
-)
-
-testProcessProject(
-  'adds type guard import to source file and skips export',
-  {
-    'test.ts': `
-    /** @see {isEmpty} ts-auto-guard:type-guard */
-    export interface Empty {}`,
-  },
-  {
-    'test.ts': `
-    import * as CustomGuardAlias from "./test.guard";
-
-    /** @see {isEmpty} ts-auto-guard:type-guard */
-    export interface Empty {}`,
-    'test.guard.ts': `
-    import { Empty } from "./test";
-
-    export function isEmpty(obj: any, _argumentName?: string): obj is Empty {
-        return (
-              (obj !== null &&
-              typeof obj === "object" ||
-              typeof obj === "function")
-           )
-    }`,
-  },
-  { options: { importGuards: 'CustomGuardAlias', preventExportImported: true } }
+  { options: { importGuards: 'CustomGuardAlias' } }
 )

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -818,8 +818,10 @@ testProcessProject(
   {
     'test.ts': `
     import * as CustomGuardAlias from "./test.guard";
+
     /** @see {isEmpty} ts-auto-guard:type-guard */
     export interface Empty {}
+
     export { CustomGuardAlias };`,
     'test.guard.ts': `
     import { Empty } from "./test";
@@ -832,5 +834,32 @@ testProcessProject(
            )
     }`,
   },
-  { options: { importGuards: 'CustomGuardAlias' } }
+  { options: { importGuards: 'CustomGuardAlias'} }
+)
+
+testProcessProject(
+  'adds type guard import to source file and skips export',
+  {
+    'test.ts': `
+    /** @see {isEmpty} ts-auto-guard:type-guard */
+    export interface Empty {}`,
+  },
+  {
+    'test.ts': `
+    import * as CustomGuardAlias from "./test.guard";
+
+    /** @see {isEmpty} ts-auto-guard:type-guard */
+    export interface Empty {}`,
+    'test.guard.ts': `
+    import { Empty } from "./test";
+
+    export function isEmpty(obj: any, _argumentName?: string): obj is Empty {
+        return (
+              (obj !== null &&
+              typeof obj === "object" ||
+              typeof obj === "function")
+           )
+    }`,
+  },
+  { options: { importGuards: 'CustomGuardAlias', preventExportImported: true } }
 )

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -807,3 +807,30 @@ testProcessProject(
   },
   { options: { exportAll: true } }
 )
+
+testProcessProject(
+  'adds type guard import to source file and also exports',
+  {
+    'test.ts': `
+    /** @see {isEmpty} ts-auto-guard:type-guard */
+    export interface Empty {}`,
+  },
+  {
+    'test.ts': `
+    import * as CustomGuardAlias from "./test.guard";
+    /** @see {isEmpty} ts-auto-guard:type-guard */
+    export interface Empty {}
+    export { CustomGuardAlias };`,
+    'test.guard.ts': `
+    import { Empty } from "./test";
+
+    export function isEmpty(obj: any, _argumentName?: string): obj is Empty {
+        return (
+              (obj !== null &&
+              typeof obj === "object" ||
+              typeof obj === "function")
+           )
+    }`,
+  },
+  { options: { importGuards: 'CustomGuardAlias', exportGuards: true } }
+)


### PR DESCRIPTION
Add TypeGuard import and export to source file.

I have a library that I'm planning to use with ts-auto-guard. I'm adding the option on my fork to have the TypeGuards imported at the start of the file and exported as a named export at the end. But I thought it might be something that would be useful for others also.
