### PR TITLE
Options for filename and truncation of imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ export function isPerson(obj: any): obj is Person {
 
 Using the `shortcircuit` option in combination with [uglify-js's `dead_code` and `global_defs` options](https://github.com/mishoo/UglifyJS2#compress-options) will let you omit the long and complicated checks from your production code.
 
+## Change Guard File Name
+
+ts-auto-guard will create a `.guard.ts` file by default, but this can be overriden.
+
+```
+ts-auto-guard --guard-file-name="debug"
+```
+
+Will result in a guard file called `.debug.ts`.
+
 ## Add Import to Source File
 ts-auto-guard supports an `ìmport-guards` flag. This flag will add an import statement at the top and a named export at the bottom of the source files for the generated type guards. The `ìmport-guards` flag also optionally accepts a custom name for the import alias, if none is passed then `TypeGuards` is used as a default.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ interface ICliOptions {
   'export-all': boolean
   'import-guards': string
   'prevent-export-imported': boolean
+  'guard-file-name': string
 }
 
 const optionList = [
@@ -50,6 +51,13 @@ const optionList = [
   },
   {
     description:
+      'Allows customisation of the filename for the generated guards file',
+    name: 'guard-file-name',
+    type: String,
+    typeLabel: '{underline extension}',
+  },
+  {
+    description:
       'Overrides the default behavior for --import-guards by skipping export from source.',
     name: 'prevent-export-imported',
     type: Boolean,
@@ -76,7 +84,10 @@ const optionList = [
 
 const options: ICliOptions = defaults(
   commandLineArgs(optionList) as ICliOptions,
-  { paths: [] as ReadonlyArray<string>, help: false }
+  {
+    paths: [] as ReadonlyArray<string>,
+    help: false,
+  }
 )
 
 async function run() {
@@ -107,6 +118,7 @@ async function run() {
         importGuards: options['import-guards'],
         preventExportImported: options['prevent-export-imported'],
         shortCircuitCondition: options.shortcircuit,
+        guardFileName: options['guard-file-name'],
       },
       project,
     })


### PR DESCRIPTION
Thank you very much for the package, we've found it very helpful.

We'd like to be able to generate two guard files, one with debug output and one without, so that we can switch out one for the other when in development mode vs the production build. The swapping is taken care of by our build process, but the hardcoded filenames and full import paths were causing issues.

The option to change the filename means we can generated `.debugguard.ts` and `.guard.ts` files. The imports were an issue since it'll change with either a developer's, or CI's, workspace location.

I hope the changes below are suitable, happy to make changes.