### PR TITLE
Using unknown types generates invalid code fix by treating it like an…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,7 +522,7 @@ function typeConditions(
   if (type.isNull()) {
     return eq(varName, 'null')
   }
-  if (type.getText() === 'any') {
+  if (type.getText() === 'any' || type.getText() === 'unknown') {
     return null
   }
   if (type.getText() === 'never') {

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -1341,3 +1341,57 @@ testProcessProject(
   },
   { 'test.ts': null }
 )
+
+testProcessProject(
+  'Deals with unknown type as it would any',
+  {
+    'test.ts': `
+      /** @see {isTestType} ts-auto-guard:type-guard */
+      export interface TestType {
+          [index: string]: unknown
+      }
+      `,
+  },
+  {
+    'test.ts': null,
+    'test.guard.ts': `
+      import { TestType } from "./test";
+
+      export function isTestType(obj: any, _argumentName?: string): obj is TestType {
+          return (
+              (obj !== null &&
+                  typeof obj === "object" ||
+                  typeof obj === "function") &&
+              Object.entries(obj)
+                  .every(([key, _value]) => (typeof key === "string"))
+          )
+      }
+      `,
+  }
+)
+
+testProcessProject(
+  'Deals with unknown type as it would any',
+  {
+    'test.ts': `
+      /** @see {isTestType} ts-auto-guard:type-guard */
+      export interface TestType {
+          test: unknown
+      }
+      `,
+  },
+  {
+    'test.ts': null,
+    'test.guard.ts': `
+      import { TestType } from "./test";
+
+      export function isTestType(obj: any, _argumentName?: string): obj is TestType {
+          return (
+              (obj !== null &&
+                  typeof obj === "object" ||
+                  typeof obj === "function")
+          )
+      }
+      `,
+  }
+)


### PR DESCRIPTION
The library appears to generate invalid code when dealing with unknown types for example.

```
/** @see {isTestType} ts-auto-guard:type-guard */
export interface TestType {
    test: unknown
}
```
Generates:

```
import { TestType } from "./test";

export function isTestType(obj: any, _argumentName?: string): obj is TestType {
    return (
        (obj !== null &&
            typeof obj === "object" ||
            typeof obj === "function") &&
        typeof obj.test === "unknown"
    )
}
```

This is just a fix by treating unknowns the same as any, let me know if my reasoning is wrong here.

Cheers