### PR TITLE
Allow overwriting of existing type guard files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1021,7 +1021,8 @@ export function processProject(
 
     const outFile = project.createSourceFile(
       outFilePath(sourceFile.getFilePath(), guardFileName),
-      ''
+      '',
+      { overwrite: true }
     )
 
     for (const typeDeclaration of allTypesDeclarations) {


### PR DESCRIPTION
Fixes https://github.com/rhys-vdw/ts-auto-guard/issues/153

This might not be the ideal solution, if refusing to overwrite is the expected behaviour we might want to add this as a CLI option to `ts-auto-guard` and simply bring it through here.