### PR TITLE
Check if object is a function if the type idicates so

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,6 +302,25 @@ function objectCondition(
 
   const callable = type.getCallSignatures().length !== 0
 
+  if (callable) {
+    // emit warning
+    const suppressComment = 'ts-auto-guard-suppress function-type'
+    const commentsBefore = declaration.getLeadingCommentRanges()
+    const commentBefore = commentsBefore[commentsBefore.length - 1]
+    if (
+      commentBefore === undefined ||
+      !commentBefore.getText().includes(suppressComment)
+    ) {
+      console.warn(
+        `
+It seems that ${varName} has a function type.
+Note that it is impossible to check if a function has the correct signiture and return type at runtime.
+To disable this warning, put comment "${suppressComment}" before the declaration.
+`
+      )
+    }
+  }
+
   if (type.isInterface()) {
     if (!Node.isInterfaceDeclaration(declaration)) {
       throw new TypeError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,11 +259,13 @@ function arrayCondition(
   )
 }
 
-function objectTypeCondition(varName: string): string {
-  return ors(
-    ands(ne(varName, 'null'), typeOf(varName, 'object')),
-    typeOf(varName, 'function')
-  )
+function objectTypeCondition(varName: string, callable: boolean): string {
+  return callable
+    ? typeOf(varName, 'function')
+    : ors(
+        ands(ne(varName, 'null'), typeOf(varName, 'object')),
+        typeOf(varName, 'function')
+      )
 }
 
 function objectCondition(
@@ -298,6 +300,8 @@ function objectCondition(
     return null
   }
 
+  const callable = type.getCallSignatures().length !== 0
+
   if (type.isInterface()) {
     if (!Node.isInterfaceDeclaration(declaration)) {
       throw new TypeError(
@@ -322,11 +326,14 @@ function objectCondition(
       }
     })
     if (conditions.length === 0) {
-      conditions.push(objectTypeCondition(varName))
+      conditions.push(objectTypeCondition(varName, callable))
     }
-    const properties = declaration
-      .getProperties()
-      .map(p => ({ name: p.getName(), type: p.getType() }))
+
+    // getProperties does not include methods like `foo(): void`
+    const properties = [
+      ...declaration.getProperties(),
+      ...declaration.getMethods(),
+    ].map(p => ({ name: p.getName(), type: p.getType() }))
     conditions.push(
       ...propertiesConditions(
         varName,
@@ -360,7 +367,7 @@ function objectCondition(
       )
     }
   } else {
-    conditions.push(objectTypeCondition(varName))
+    conditions.push(objectTypeCondition(varName, callable))
     // Get object literal properties...
     try {
       const properties = type.getProperties()

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -1395,3 +1395,33 @@ testProcessProject(
       `,
   }
 )
+
+testProcessProject(
+  'Check if property is indeed a function for any function type.',
+  // should also emit a warning about how it is not possible to check function type at runtime.
+  {
+    'test.ts': `
+      /** @see {isTestType} ts-auto-guard:type-guard */
+      export interface TestType {
+        test: (() => void);
+      }
+    `,
+  },
+  {
+    'test.ts': null,
+    'test.guard.ts': `
+      import { TestType } from "./test";
+      
+      export function isTestType(obj: any, _argumentName?: string): obj is TestType {
+          return (
+              (obj !== null &&
+                  typeof obj === "object" ||
+                  typeof obj === "function") &&
+              (obj.test !== null &&
+                  typeof obj.test === "function")
+          )
+      }
+    `,
+  },
+  { only: true }
+)

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -1397,13 +1397,18 @@ testProcessProject(
 )
 
 testProcessProject(
-  'Check if property is indeed a function for any function type.',
+  'Check if any callable properties is a function',
   // should also emit a warning about how it is not possible to check function type at runtime.
   {
     'test.ts': `
       /** @see {isTestType} ts-auto-guard:type-guard */
       export interface TestType {
-        test: (() => void);
+        test: (() => void)
+        test2(someArg: number): boolean
+        test3: {
+          (someArg: string): number
+          test3Arg: number;
+        }
       }
     `,
   },
@@ -1417,11 +1422,39 @@ testProcessProject(
               (obj !== null &&
                   typeof obj === "object" ||
                   typeof obj === "function") &&
-              (obj.test !== null &&
-                  typeof obj.test === "function")
+              typeof obj.test === "function" &&
+              typeof obj.test3 === "function" &&
+              typeof obj.test3.test3Arg === "number" &&
+              typeof obj.test2 === "function"
           )
       }
     `,
+  }
+)
+
+testProcessProject(
+  'Check if callable interface is a function',
+  // should also emit a warning about how it is not possible to check function type at runtime.
+  {
+    'test.ts': `
+      /** @see {isTestType} ts-auto-guard:type-guard */
+      export interface TestType {
+        (someArg: string): number
+        arg: number;
+      }
+    `,
   },
-  { only: true }
+  {
+    'test.ts': null,
+    'test.guard.ts': `
+      import { TestType } from "./test";
+      
+      export function isTestType(obj: any, _argumentName?: string): obj is TestType {
+          return (
+              typeof obj === "function" &&
+              typeof obj.arg === "number"
+          )
+      }
+    `,
+  }
 )

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -1404,7 +1404,9 @@ testProcessProject(
       /** @see {isTestType} ts-auto-guard:type-guard */
       export interface TestType {
         test: (() => void)
+        // ts-auto-guard-suppress function-type
         test2(someArg: number): boolean
+        // some other comments
         test3: {
           (someArg: string): number
           test3Arg: number;


### PR DESCRIPTION
closes #155.

If a properties has a function type, it checks if the object is actually a function in the type guard.

It would also emit a warning regarding how the signature of the function will never be tested in the type guard. The warning can be suppressed by putting comment `ts-auto-guard-suppress function-type` before the declaration. I'm happy to change the warning or the way the warning is suppressed.

I tried to find out how to test the warning in console output with tape but to no avail. If anyone know how to do it please tell me or you tackle it yourself. Otherwise we'll probably have to make do with the fact that the emitted warning will not be tested.