### PR TITLE
Fix class imports from node modules

### DIFF
--- a/tests/import.ts
+++ b/tests/import.ts
@@ -1,0 +1,172 @@
+import test from 'tape'
+import path from 'path'
+import fs from 'fs'
+import { Project } from 'ts-morph'
+import { processProject } from '../src'
+const WorkingDir = path.dirname(__filename)
+const TestFile = 'ImportTest.ts'
+const TestFilePath = path.join(WorkingDir, TestFile)
+
+interface TestDefinition {
+  message: string
+  inputFile: string
+  guardFile: string
+}
+
+// Test blueprint for running different test definitions
+class Blueprint {
+  inputContents: string
+  expectedContents: string
+  message: string
+  constructor(message: string, inputFile: string, guardFile: string) {
+    this.inputContents = inputFile
+    this.expectedContents = guardFile
+    this.message = message
+  }
+  createTestFile() {
+    fs.writeFileSync(TestFilePath, this.inputContents)
+  }
+  deleteTestFile() {
+    fs.unlinkSync(TestFilePath)
+  }
+  buildProject() {
+    const project = new Project({
+      skipAddingFilesFromTsConfig: true,
+      compilerOptions: { strict: true },
+      useInMemoryFileSystem: false,
+    })
+    project.addSourceFileAtPath(TestFilePath)
+    project.saveSync()
+    return project
+  }
+  run() {
+    test(this.message, t => {
+      this.createTestFile()
+      const project = this.buildProject()
+      t.doesNotThrow(() => {
+        processProject(project, { exportAll: true })
+      })
+      const guardFile = project.getSourceFiles()[0]
+      guardFile.formatText()
+      t.equal(guardFile.getText(), this.expectedContents)
+      t.end()
+      this.deleteTestFile()
+    })
+  }
+}
+
+function genBlueprint(def: TestDefinition) {
+  return new Blueprint(def.message, def.inputFile, def.guardFile)
+}
+
+// Define grouping of tests
+const blueprints = [
+  genBlueprint({
+    message:
+      'interfaces from scoped package in node modules requires no import',
+    inputFile: `import { InMemoryFileSystemHostOptions } from "@ts-morph/common";
+export interface Foo {
+  target: InMemoryFileSystemHostOptions
+}`,
+    guardFile: `import { Foo } from "./ImportTest";
+
+export function isFoo(obj: any, _argumentName?: string): obj is Foo {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.target !== null &&
+            typeof obj.target === "object" ||
+            typeof obj.target === "function") &&
+        (typeof obj.target.skipLoadingLibFiles === "undefined" ||
+            obj.target.skipLoadingLibFiles === false ||
+            obj.target.skipLoadingLibFiles === true)
+    )
+}
+`,
+  }),
+  genBlueprint({
+    message: 'type from scoped package in node modules requires no import',
+    inputFile: `import { ResolutionHostFactory } from "@ts-morph/common";
+export interface Foo {
+  target: ResolutionHostFactory
+}`,
+    guardFile: `import { Foo } from "./ImportTest";
+
+export function isFoo(obj: any, _argumentName?: string): obj is Foo {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        typeof obj.target === "function"
+    )
+}
+`,
+  }),
+  genBlueprint({
+    message: 'using class from scoped package in node modules',
+    inputFile: `import { CompilerOptionsContainer } from "@ts-morph/common";
+export interface Foo {
+  target: CompilerOptionsContainer
+}`,
+    guardFile: `import { CompilerOptionsContainer } from "@ts-morph/common";
+import { Foo } from "./ImportTest";
+
+export function isFoo(obj: any, _argumentName?: string): obj is Foo {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        obj.target instanceof CompilerOptionsContainer
+    )
+}
+`,
+  }),
+  genBlueprint({
+    message: 'using multiple classes from scoped package in node modules',
+    inputFile: `import { CompilerOptionsContainer, TsConfigResolver, InMemoryFileSystemHost } from "@ts-morph/common";
+export interface Foo {
+  target: CompilerOptionsContainer,
+  res: TsConfigResolver,
+  fs: InMemoryFileSystemHost
+}`,
+    guardFile: `import { CompilerOptionsContainer, TsConfigResolver, InMemoryFileSystemHost } from "@ts-morph/common";
+import { Foo } from "./ImportTest";
+
+export function isFoo(obj: any, _argumentName?: string): obj is Foo {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        obj.target instanceof CompilerOptionsContainer &&
+        obj.res instanceof TsConfigResolver &&
+        obj.fs instanceof InMemoryFileSystemHost
+    )
+}
+`,
+  }),
+  genBlueprint({
+    message: 'using class from unscoped package in node modules',
+    inputFile: `import { Directory } from "ts-morph";
+export interface Foo {
+  dir: Directory
+}`,
+    guardFile: `import { Directory } from "ts-morph";
+import { Foo } from "./ImportTest";
+
+export function isFoo(obj: any, _argumentName?: string): obj is Foo {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        obj.dir instanceof Directory
+    )
+}
+`,
+  }),
+]
+
+// Run all tests
+blueprints.forEach(bp => {
+  bp.run()
+})


### PR DESCRIPTION
Fixes #162 
## How `import` statements are currently treated
Let's use this simple export as an example:
```ts
// Foo.ts
import { DirectoryAddOptions } from "ts-morph";
export interface Foo {
  options: DirectoryAddOptions
}
```

For every `export` found within `Foo.ts`, the ts-auto-guard library will generate an accompanying guard for the exported variable. Regardless of how many exports are found, all guards are placed within the guard file: `Foo.guard.ts`.

Each property of the exported variable is [analyzed to determine its type](https://github.com/rhys-vdw/ts-auto-guard/blob/eaf7bdf46233aa8933b76ad222944bdb7575160c/src/index.ts#L532). In our example above, we only have one exported variable `Foo` which has a single property `options`. The expected guard file produced is as shown:
```ts
// Foo.guard.ts
/*
 * Generated type guards for "Foo.ts".
 * WARNING: Do not manually change this file.
 */
import { Foo } from "./Foo";

export function isFoo(obj: any, _argumentName?: string): obj is Foo {
    return (
        (obj !== null &&
            typeof obj === "object" ||
            typeof obj === "function") &&
        (obj.options !== null &&
            typeof obj.options === "object" ||
            typeof obj.options === "function") &&
        (typeof obj.options.recursive === "undefined" ||
            obj.options.recursive === false ||
            obj.options.recursive === true)
    )
}
```
**NOTICE**: There is no reference of `DirectoryAddOptions` within this guard file. That is because ts-auto-guard doesn't need it! It ONLY requires referencing the named type of a variable if it is a class. In our example, [DirectoryAddOptions is an interface](https://github.com/dsherret/ts-morph/blob/526e0dd5ef2e6f95c617fe08da0400d46dc94c26/packages/ts-morph/src/fileSystem/Directory.ts#L10-L16).

### The Issue : #162 
If we instead change the options variable to a class type, [like Directory](https://github.com/dsherret/ts-morph/blob/526e0dd5ef2e6f95c617fe08da0400d46dc94c26/packages/ts-morph/src/fileSystem/Directory.ts#L29), we encounter some problems.
```ts
// Foo.ts
import { Directory } from "ts-morph";
export interface Foo {
  options: Directory
}
```
```ts
// Foo.guard.ts
/*
 * Generated type guards for "Foo.ts".
 * WARNING: Do not manually change this file.
 */
import { Directory } from "../node_modules/ts-morph/lib/ts-morph";
import { Foo } from "./Foo";

export function isFoo(obj: any, _argumentName?: string): obj is Foo {
    return (
        (obj !== null &&
            typeof obj === "object" ||
            typeof obj === "function") &&
        obj.options instanceof Directory
    )
}
```
As you can see, the guard file references the package `ts-morph` with a relative path within node_modules. This does not follow the [TypeScript convention](https://www.typescriptlang.org/docs/handbook/module-resolution.html#relative-vs-non-relative-module-imports) for non-relative package imports. In some cases, these relative imports do not correctly import the desired variable. _This PR aims to address these problems with relative class imports._

# The Fix
This PR adds a check for each import statement being added to the guard file. If the accompanying import is found within the node modules directory, it will explicitly copy the reference found within the source file. For our above example, we grab the package reference `ts-morph` found in `Foo.ts`. This solves our problem of referencing npm modules.

One alternative method, which was NOT used, was to copy the entire import statement found within the source file. However, this was discouraged as it has the potential to include more variables than necessary within the guard file. For example, a file like:
```ts
// Bar.js
import { Directory, DirectoryAddOptions } from "ts-morph";
console.log(DirectoryAddOptions)
export interface Bar {
  dir: Directory
}
```
will produce the guard file:
```ts
// Bar.guard.ts
/*
 * Generated type guards for "Foo.ts".
 * WARNING: Do not manually change this file.
 */
import { Directory, DirectoryAddOptions } from "ts-morph";
import { Bar } from "./Bar";

export function isBar(obj: any, _argumentName?: string): obj is Foo {
    return (
        (obj !== null &&
            typeof obj === "object" ||
            typeof obj === "function") &&
        obj.options instanceof Directory
    )
}
```
**NOTICE**: we import `DirectoryAddOptions` even though it is not used anywhere. This will raise an error for users with the TypeScript compiler option: [noUnusedLocals](https://www.typescriptlang.org/tsconfig#noUnusedLocals). Therefore, I consider it a non-solution.

## Testing
The current tests use an [inMemoryFileSystem](https://github.com/dsherret/ts-morph/blob/526e0dd5ef2e6f95c617fe08da0400d46dc94c26/packages/ts-morph/src/fileSystem/Directory.ts#L10) for generating test projects. However, this does not adequately simulate a project containing node-modules. Therefore, I created another test file to auto generate a local file for every test. This file `ImportTest.ts` is created and destroyed for every test to eliminate contamination between tests. It's written into the local directory `/tests` each time. 

Since it lives in the local file system, within the local TypeScript project, we can adequately test class imports from npm packages already found in the ts-auto-guard project. The use of the `ts-morph` package for tests was chosen because this project already heavily relies on ts-morph types. Therefore, it is highly unlikely to be removed in the future, preventing test failures.

