### PR TITLE
Issue #169 Issue #170 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export interface Person { // !do not forget to export - only exported types are 
 ### Process all types
 Use `--export-all` parameter to process all exported types:
 ```
-$ ts-auto-guard --export-all
+$ ts-auto-guard --export-all 'src/domain/*.ts'
 ```
 
 ## Debug mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ts-auto-guard",
-      "version": "1.0.0-alpha.29",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/command-line-args": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,8 @@ function getTypeGuardName(
     const name = symbols
       .filter(x => x && x.getName() !== '__type')[0]
       ?.getName()
-    if (name) {
+    const isPrimitive = ['undefined', 'null', 'boolean', 'bigint', 'string', 'number'].includes(t.getText());
+    if (name && !isPrimitive) {
       return 'is' + name
     }
   }
@@ -324,7 +325,7 @@ To disable this warning, put comment "${suppressComment}" before the declaration
   if (type.isInterface()) {
     if (!Node.isInterfaceDeclaration(declaration)) {
       throw new TypeError(
-        'Extected declaration to be an interface delcaration!'
+        'Extected declaration to be an interface declaration!'
       )
     }
     declaration.getBaseTypes().forEach(baseType => {
@@ -668,7 +669,7 @@ function propertyConditions(
   const propertyName = property.name
 
   const isIdentifier =
-    propertyName[0] !== '"' && propertyName[0] !== "'" && !hasSpaces
+    propertyName[0] !== '"' && propertyName[0] !== "'" && !hasSpaces && isNaN(parseInt(propertyName))
   const strippedName = propertyName.replace(/"/g, '')
   const varName = isIdentifier
     ? `${objName}.${propertyName}`

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -1031,6 +1031,76 @@ testProcessProject(
 )
 
 testProcessProject(
+    'generated type guards for numeric enums in optional records',
+    {
+      'test.ts': `
+    export enum Types{
+        TheGood = 1,
+        TheBad,
+        TheTypeSafe
+    }
+    export interface TestItem  {
+      room: Partial<Record<Types, string>>>;
+    }`,
+    },
+    {
+      'test.ts': null,
+      'test.guard.ts': `
+      import { Types, TestItem } from "./test";
+
+      export function isTypes(obj: any, _argumentName?: string): obj is Types {
+          return (
+              (obj === Types.TheGood ||
+                  obj === Types.TheBad ||
+                  obj === Types.TheTypeSafe)
+          )
+      }
+
+      export function isTestItem(obj: any, _argumentName?: string): obj is TestItem {
+          return (
+              (obj !== null &&
+                  typeof obj === "object" ||
+                  typeof obj === "function") &&
+              (obj.room !== null &&
+                  typeof obj.room === "object" ||
+                  typeof obj.room === "function") &&
+              (typeof obj.room["1"] === "undefined" ||
+                  typeof obj.room["1"] === "string") &&
+              (typeof obj.room["2"] === "undefined" ||
+                  typeof obj.room["2"] === "string") &&
+              (typeof obj.room["3"] === "undefined" ||
+                  typeof obj.room["3"] === "string")
+          )
+      }`,
+    },
+    { options: { exportAll: true } }
+)
+
+testProcessProject(
+    'no type guards for primitive alias types',
+    {
+      'test.ts': `
+      export type Days = number
+      export type UUID = string
+      export enum Types { TheGood }
+      export type Blank = undefined
+      export type AlwaysNull = null`,
+    },
+    {
+      'test.ts': null,
+      'test.guard.ts': `
+    import { Types } from "./test";
+    
+    export function isTypes(obj: any, _argumentName?: string): obj is Types {
+        return (
+            obj === Types.TheGood
+        )
+    }`,
+    },
+    { options: { exportAll: true } }
+)
+
+testProcessProject(
   'generated type guards for arrays of any',
   {
     'test.ts': `


### PR DESCRIPTION
- Improve README example of the `--export-all `option
- When using export-all option, don't generate guards for type alias to primitives.
- Detect that hashmap properties that parse to numbers are not proper identifiers, and use the bracket notation to access them.

Fixes #169 Fixes #170 