### PR TITLE
support for special characters in property names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -695,16 +695,11 @@ function propertyConditions(
   options: IProcessOptions
 ): string | null {
   const { debug } = options
-  const hasSpaces =
-    (property.name || '').includes(' ') &&
-    [`'`, `"`].every(quote => !(propertyName || '').includes(quote))
   const propertyName = property.name
 
-  const isIdentifier =
-    propertyName[0] !== '"' &&
-    propertyName[0] !== "'" &&
-    !hasSpaces &&
-    isNaN(parseInt(propertyName))
+  // can't start with a number (\d) and then only consists of letters, numbers and the underscore (\w)
+  const validPropertyNameRegex = /^(?!\d)[\w$]+$/
+  const isIdentifier = validPropertyNameRegex.test(propertyName)
   const strippedName = propertyName.replace(/"/g, '')
   const varName = isIdentifier
     ? `${objName}.${propertyName}`


### PR DESCRIPTION
Added support and test coverage for special characters in type and interface property names, numeric property names and the empty string as a property name.