### PR TITLE
all property accesses use index accessor instead of dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ export function isPerson(obj: unknown): obj is Person {
   const typedObj = obj as Person
   return (
     typeof typedObj === 'object' &&
-    typeof typedObj.name === 'string' &&
-    (typeof typedObj.age === 'undefined' || typeof typedObj.age === 'number') &&
-    Array.isArray(typedObj.children) &&
-    typedObj.children.every(e => isPerson(e))
+    typeof typedObj['name'] === 'string' &&
+    (typeof typedObj['age'] === 'undefined' ||
+      typeof typedObj['age'] === 'number') &&
+    Array.isArray(typedObj['children']) &&
+    typedObj['children'].every(e => isPerson(e))
   )
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -697,16 +697,9 @@ function propertyConditions(
   const { debug } = options
   const propertyName = property.name
 
-  // can't start with a number (\d) and then only consists of letters, numbers and the underscore (\w)
-  const validPropertyNameRegex = /^(?!\d)\w+$/
-  const isIdentifier = validPropertyNameRegex.test(propertyName)
   const strippedName = propertyName.replace(/"/g, '')
-  const varName = isIdentifier
-    ? `${objName}.${propertyName}`
-    : `${objName}["${strippedName}"]`
-  const propertyPath = isIdentifier
-    ? `${path}.${propertyName}`
-    : `${path}["${strippedName}"]`
+  const varName = `${objName}["${strippedName}"]`
+  const propertyPath = `${path}["${strippedName}"]`
 
   let expectedType = property.type.getText()
   const conditions = typeConditions(

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -212,8 +212,8 @@ testProcessProject(
             (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-            typeof typedObj.foo === "number" &&
-            typeof typedObj.bar === "string"
+            typeof typedObj["foo"] === "number" &&
+            typeof typedObj["bar"] === "string"
         )
     }`,
   },
@@ -268,12 +268,12 @@ testProcessProject(
         (typedObj !== null &&
           typeof typedObj === "object" ||
           typeof typedObj === "function") &&
-          evaluate(typeof typedObj.foo === "number", \`\${argumentName}.foo\`, "number", typedObj.foo) &&
-          evaluate(isBar(typedObj.bar) as boolean, \`\${argumentName}.bar\`, "import(\\"/foo/bar/test\\").Bar", typedObj.bar) &&
-          evaluate(Array.isArray(typedObj.bars) &&
-            typedObj.bars.every((e: any) =>
+          evaluate(typeof typedObj["foo"] === "number", \`\${argumentName}["foo"]\`, "number", typedObj["foo"]) &&
+          evaluate(isBar(typedObj["bar"]) as boolean, \`\${argumentName}["bar"]\`, "import(\\"/foo/bar/test\\").Bar", typedObj["bar"]) &&
+          evaluate(Array.isArray(typedObj["bars"]) &&
+            typedObj["bars"].every((e: any) =>
               isBar(e) as boolean
-            ), \`\${argumentName}.bars\`, "import(\\"/foo/bar/test\\").Bar[]", typedObj.bars)
+            ), \`\${argumentName}["bars"]\`, "import(\\"/foo/bar/test\\").Bar[]", typedObj["bars"])
         )
     }
 
@@ -283,7 +283,7 @@ testProcessProject(
         (typedObj !== null &&
           typeof typedObj === "object" ||
           typeof typedObj === "function") &&
-          evaluate(typeof typedObj.bar === "number", \`\${argumentName}.bar\`, "number", typedObj.bar)
+          evaluate(typeof typedObj["bar"] === "number", \`\${argumentName}["bar"]\`, "number", typedObj["bar"])
         )
     }
     `,
@@ -316,8 +316,8 @@ testProcessProject(
             (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-            typeof typedObj.foo === "number" &&
-            typeof typedObj.bar === "string"
+            typeof typedObj["foo"] === "number" &&
+            typeof typedObj["bar"] === "string"
         )
     }`,
   },
@@ -351,8 +351,8 @@ testProcessProject(
             (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-            typeof typedObj.foo === "number" &&
-            typeof typedObj.bar === "string"
+            typeof typedObj["foo"] === "number" &&
+            typeof typedObj["bar"] === "string"
         )
     }`,
   }
@@ -562,8 +562,8 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.foo === "number" &&
-            typeof typedObj.bar === "string"
+            typeof typedObj["foo"] === "number" &&
+            typeof typedObj["bar"] === "string"
         )
     }`,
   }
@@ -591,12 +591,12 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            ( typeof typedObj.foo === "undefined" ||
-              typeof typedObj.foo === "number" ) &&
-            ( typeof typedObj.bar === "undefined" ||
-              typeof typedObj.bar === "number" ) &&
-            ( typeof typedObj.baz === "undefined" ||
-              typeof typedObj.baz === "number" )
+            ( typeof typedObj["foo"] === "undefined" ||
+              typeof typedObj["foo"] === "number" ) &&
+            ( typeof typedObj["bar"] === "undefined" ||
+              typeof typedObj["bar"] === "number" ) &&
+            ( typeof typedObj["baz"] === "undefined" ||
+              typeof typedObj["baz"] === "number" )
         )
     }`,
   }
@@ -626,10 +626,10 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            (typedObj.foo !== null &&
-              typeof typedObj.foo === "object" ||
-              typeof typedObj.foo === "function") &&
-            typeof typedObj.foo.bar === "number"
+            (typedObj["foo"] !== null &&
+              typeof typedObj["foo"] === "object" ||
+              typeof typedObj["foo"] === "function") &&
+            typeof typedObj["foo"]["bar"] === "number"
         )
     }`,
   }
@@ -660,7 +660,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.bar === "number"
+            typeof typedObj["bar"] === "number"
         )
     }
 
@@ -670,7 +670,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            isBar(typedObj.foo) as boolean
+            isBar(typedObj["foo"]) as boolean
         )
     }`,
   }
@@ -700,8 +700,8 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.bar === "number" &&
-            typeof typedObj.foo === "number"
+            typeof typedObj["bar"] === "number" &&
+            typeof typedObj["foo"] === "number"
         )
     }`,
   }
@@ -732,7 +732,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.bar === "number"
+            typeof typedObj["bar"] === "number"
         )
     }
 
@@ -740,7 +740,7 @@ testProcessProject(
         const typedObj = obj as Foo
         return (
             isBar(typedObj) as boolean &&
-            typeof typedObj.foo === "number"
+            typeof typedObj["foo"] === "number"
         )
     }`,
   }
@@ -770,8 +770,8 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.bar === "number" &&
-            typeof typedObj.foo === "number"
+            typeof typedObj["bar"] === "number" &&
+            typeof typedObj["foo"] === "number"
         )
     }`,
   }
@@ -802,7 +802,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.bar === "number"
+            typeof typedObj["bar"] === "number"
         )
     }
 
@@ -810,7 +810,7 @@ testProcessProject(
         const typedObj = obj as Foo
         return (
             isBar(typedObj) as boolean &&
-            typeof typedObj.foo === "number"
+            typeof typedObj["foo"] === "number"
         )
     }`,
   }
@@ -836,7 +836,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.foo === "number"
+            typeof typedObj["foo"] === "number"
         )
     }`,
   }
@@ -865,7 +865,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.foo === "number"
+            typeof typedObj["foo"] === "number"
         )
     }`,
   }
@@ -892,7 +892,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-            typeof typedObj.foo === "number"
+            typeof typedObj["foo"] === "number"
         )
     }`,
   },
@@ -950,7 +950,7 @@ testProcessProject(
             (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-          typeof typedObj.value === "string"
+          typeof typedObj["value"] === "string"
           )
       }
 
@@ -968,8 +968,8 @@ testProcessProject(
          (typedObj !== null &&
               typeof typedObj === "object" ||
               typeof typedObj === "function") &&
-         isPropertyValueType(typedObj.name) as boolean &&
-         isPropertyValueType(typedObj.value) as boolean
+         isPropertyValueType(typedObj["name"]) as boolean &&
+         isPropertyValueType(typedObj["value"]) as boolean
        )
      }
     `,
@@ -1013,8 +1013,8 @@ testProcessProject(
             (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-                Array.isArray(typedObj.branches) &&
-                typedObj.branches.every((e: any) =>
+                Array.isArray(typedObj["branches"]) &&
+                typedObj["branches"].every((e: any) =>
                     isBranch2(e) as boolean
                 ))
         )
@@ -1027,8 +1027,8 @@ testProcessProject(
                 (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-                Array.isArray(typedObj.branches) &&
-                typedObj.branches.every((e: any) =>
+                Array.isArray(typedObj["branches"]) &&
+                typedObj["branches"].every((e: any) =>
                     isBranch3(e) as boolean
                 ) ||
                 Array.isArray(typedObj) &&
@@ -1036,7 +1036,7 @@ testProcessProject(
                     (e !== null &&
                       typeof e === "object" ||
                       typeof e === "function")  &&
-                    isBranch3(e.branches) as boolean
+                    isBranch3(e["branches"]) as boolean
                 ))
         )
     }`,
@@ -1061,13 +1061,13 @@ testProcessProject(
             ((typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-                typedObj.type === "a" &&
-                typeof typedObj.value === "number" ||
+                typedObj["type"] === "a" &&
+                typeof typedObj["value"] === "number" ||
                 (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-                typedObj.type === "b" &&
-                typeof typedObj.value === "string")
+                typedObj["type"] === "b" &&
+                typeof typedObj["value"] === "string")
             )
     }`,
   },
@@ -1134,15 +1134,15 @@ testProcessProject(
               (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-              (typedObj.room !== null &&
-                  typeof typedObj.room === "object" ||
-                  typeof typedObj.room === "function") &&
-              (typeof typedObj.room["1"] === "undefined" ||
-                  typeof typedObj.room["1"] === "string") &&
-              (typeof typedObj.room["2"] === "undefined" ||
-                  typeof typedObj.room["2"] === "string") &&
-              (typeof typedObj.room["3"] === "undefined" ||
-                  typeof typedObj.room["3"] === "string")
+              (typedObj["room"] !== null &&
+                  typeof typedObj["room"] === "object" ||
+                  typeof typedObj["room"] === "function") &&
+              (typeof typedObj["room"]["1"] === "undefined" ||
+                  typeof typedObj["room"]["1"] === "string") &&
+              (typeof typedObj["room"]["2"] === "undefined" ||
+                  typeof typedObj["room"]["2"] === "string") &&
+              (typeof typedObj["room"]["3"] === "undefined" ||
+                  typeof typedObj["room"]["3"] === "string")
           )
       }`,
   },
@@ -1169,7 +1169,7 @@ testProcessProject(
               (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-              Array.isArray(typedObj.value)
+              Array.isArray(typedObj["value"])
           )
       }`,
   },
@@ -1198,13 +1198,13 @@ testProcessProject(
                 (typedObj !== null &&
                     typeof typedObj === "object" ||
                     typeof typedObj === "function") &&
-                Array.isArray(typedObj.value) &&
-                typedObj.value.every((e: any) =>
+                Array.isArray(typedObj["value"]) &&
+                typedObj["value"].every((e: any) =>
                     (e !== null &&
                         typeof e === "object" ||
                         typeof e === "function") &&
-                    Array.isArray(e.value) &&
-                    e.value.every((e: any) =>
+                    Array.isArray(e["value"]) &&
+                    e["value"].every((e: any) =>
                         typeof e === "number"
                     )
                 )
@@ -1330,8 +1330,8 @@ testProcessProject(
                 (typedObj !== null &&
                     typeof typedObj === "object" ||
                     typeof typedObj === "function") &&
-                (typeof typedObj.someKey === "string" ||
-                    typeof typedObj.someKey === "number")
+                (typeof typedObj["someKey"] === "string" ||
+                    typeof typedObj["someKey"] === "number")
             )
         }
         `,
@@ -1361,8 +1361,8 @@ testProcessProject(
               (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-              (typedObj.someKey === "some" ||
-                  typedObj.someKey === "key") &&
+              (typedObj["someKey"] === "some" ||
+                  typedObj["someKey"] === "key") &&
               Object.entries<any>(typedObj)
                   .filter(([key]) => !["someKey"].includes(key))
                   .every(([key, value]) => ((value === "string" ||
@@ -1557,10 +1557,10 @@ testProcessProject(
               (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-              typeof typedObj.test === "function" &&
-              typeof typedObj.test3 === "function" &&
-              typeof typedObj.test3.test3Arg === "number" &&
-              typeof typedObj.test2 === "function"
+              typeof typedObj["test"] === "function" &&
+              typeof typedObj["test3"] === "function" &&
+              typeof typedObj["test3"]["test3Arg"] === "number" &&
+              typeof typedObj["test2"] === "function"
           )
       }
     `,
@@ -1588,7 +1588,7 @@ testProcessProject(
           const typedObj = obj as TestType
           return (
               typeof typedObj === "function" &&
-              typeof typedObj.arg === "number"
+              typeof typedObj["arg"] === "number"
           )
       }
     `,
@@ -1613,11 +1613,11 @@ testProcessProject(
             (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-                typeof typedObj.foo === "number" &&
+                typeof typedObj["foo"] === "number" &&
                 (typedObj !== null &&
                   typeof typedObj === "object" ||
                   typeof typedObj === "function") &&
-                typeof typedObj.bar === "string"
+                typeof typedObj["bar"] === "string"
             )
     }`,
   },
@@ -1643,8 +1643,8 @@ testProcessProject(
             (typedObj !== null &&
                 typeof typedObj === "object" ||
                 typeof typedObj === "function") &&
-            Array.isArray(typedObj.b) &&
-            typeof typedObj.b[0] === "number"
+            Array.isArray(typedObj["b"]) &&
+            typeof typedObj["b"][0] === "number"
         )
     }`,
   },

--- a/tests/import.ts
+++ b/tests/import.ts
@@ -76,12 +76,12 @@ export function isFoo(obj: unknown): obj is Foo {
         (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-        (typedObj.target !== null &&
-            typeof typedObj.target === "object" ||
-            typeof typedObj.target === "function") &&
-        (typeof typedObj.target.skipLoadingLibFiles === "undefined" ||
-            typedObj.target.skipLoadingLibFiles === false ||
-            typedObj.target.skipLoadingLibFiles === true)
+        (typedObj["target"] !== null &&
+            typeof typedObj["target"] === "object" ||
+            typeof typedObj["target"] === "function") &&
+        (typeof typedObj["target"]["skipLoadingLibFiles"] === "undefined" ||
+        typedObj["target"]["skipLoadingLibFiles"] === false ||
+        typedObj["target"]["skipLoadingLibFiles"] === true)
     )
 }
 `,
@@ -100,7 +100,7 @@ export function isFoo(obj: unknown): obj is Foo {
         (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-        typeof typedObj.target === "function"
+        typeof typedObj["target"] === "function"
     )
 }
 `,
@@ -120,7 +120,7 @@ export function isFoo(obj: unknown): obj is Foo {
         (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-        typedObj.target instanceof CompilerOptionsContainer
+        typedObj["target"] instanceof CompilerOptionsContainer
     )
 }
 `,
@@ -142,9 +142,9 @@ export function isFoo(obj: unknown): obj is Foo {
         (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-        typedObj.target instanceof CompilerOptionsContainer &&
-        typedObj.res instanceof TsConfigResolver &&
-        typedObj.fs instanceof InMemoryFileSystemHost
+        typedObj["target"] instanceof CompilerOptionsContainer &&
+        typedObj["res"] instanceof TsConfigResolver &&
+        typedObj["fs"] instanceof InMemoryFileSystemHost
     )
 }
 `,
@@ -164,7 +164,7 @@ export function isFoo(obj: unknown): obj is Foo {
         (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-        typedObj.dir instanceof Directory
+        typedObj["dir"] instanceof Directory
     )
 }
 `,

--- a/tests/import.ts
+++ b/tests/import.ts
@@ -80,8 +80,8 @@ export function isFoo(obj: unknown): obj is Foo {
             typeof typedObj["target"] === "object" ||
             typeof typedObj["target"] === "function") &&
         (typeof typedObj["target"]["skipLoadingLibFiles"] === "undefined" ||
-        typedObj["target"]["skipLoadingLibFiles"] === false ||
-        typedObj["target"]["skipLoadingLibFiles"] === true)
+            typedObj["target"]["skipLoadingLibFiles"] === false ||
+            typedObj["target"]["skipLoadingLibFiles"] === true)
     )
 }
 `,


### PR DESCRIPTION
whoops had to rebase on top of #196

There doesn't seem to be a reliable way to tell if a property name is safe to use with the dot notation.

Instead, this uses index accessor in all cases.

Should close #191 and is a partial fix for #167.