### PR TITLE
Gitignore .log folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /lib
 /.idea
+/.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /lib
 /.idea
 /.log
+/src/.log


### PR DESCRIPTION
The .log folder seems to be generated when tsc compiles, But I don't really see a reason for it to be included in the repo so it might be best to add it to the .gitignore