### PR TITLE
Fix type only imports 166

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1160,6 +1160,7 @@ export function processProject(
               kind: StructureKind.ImportDeclaration,
               moduleSpecifier,
               namedImports,
+              isTypeOnly: true,
             })
             return structures
           },

--- a/tests/features/adds_type_guard_import_to_source_file_and_also_exports.test.ts
+++ b/tests/features/adds_type_guard_import_to_source_file_and_also_exports.test.ts
@@ -19,7 +19,7 @@ export interface Empty { }
     export interface Empty {}
     export { CustomGuardAlias };`,
     'test.guard.ts': `
-    import { Empty } from "./test";
+    import type { Empty } from "./test";
 
     export function isEmpty(obj: unknown): obj is Empty {
         const typedObj = obj as Empty

--- a/tests/features/allows_the_name_of_the_guard_file_file_to_be_specified.test.ts
+++ b/tests/features/allows_the_name_of_the_guard_file_file_to_be_specified.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.debug.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/any_and_unknown_work_in_interesction_types.test.ts
+++ b/tests/features/any_and_unknown_work_in_interesction_types.test.ts
@@ -14,7 +14,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { AnyAndString, UnknownAndString, AnyAndUnknownAndString } from "./test";
+    import type { AnyAndString, UnknownAndString, AnyAndUnknownAndString } from "./test";
 
     export function isAnyAndString(obj: unknown): obj is AnyAndString {
         const typedObj = obj as AnyAndString

--- a/tests/features/any_and_unknown_work_in_union_types.test.ts
+++ b/tests/features/any_and_unknown_work_in_union_types.test.ts
@@ -14,7 +14,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { AnyOrString, UnknownOrString, AnyOrUnknownOrString } from "./test";
+    import type { AnyOrString, UnknownOrString, AnyOrUnknownOrString } from "./test";
 
     export function isAnyOrString(obj: unknown): obj is AnyOrString {
         const typedObj = obj as AnyOrString

--- a/tests/features/check_if_any_callable_properties_is_a_function.test.ts
+++ b/tests/features/check_if_any_callable_properties_is_a_function.test.ts
@@ -21,7 +21,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType } from "./test";
+      import type { TestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/check_if_callable_interface_is_a_function.test.ts
+++ b/tests/features/check_if_callable_interface_is_a_function.test.ts
@@ -15,7 +15,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType } from "./test";
+      import type { TestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/correctly_handles_default_export.test.ts
+++ b/tests/features/correctly_handles_default_export.test.ts
@@ -15,7 +15,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import Foo from "./test";
+    import type Foo from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/deals_with_unknown_type_as_it_would_any.test.ts
+++ b/tests/features/deals_with_unknown_type_as_it_would_any.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType } from "./test";
+      import type { TestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/duplicate_guard_re-exports.test.ts
+++ b/tests/features/duplicate_guard_re-exports.test.ts
@@ -17,7 +17,7 @@ testProcessProject(
     * Generated type guards for "custom.ts".
     * WARNING: Do not manually change this file.
     */
-    import { Color } from "./custom";
+    import type { Color } from "./custom";
 
     export function isColor(obj: unknown): obj is Color {
         const typedObj = obj as Color
@@ -46,7 +46,7 @@ testProcessProject(
     * Generated type guards for "custom.ts".
     * WARNING: Do not manually change this file.
     */
-    import { Color } from "./custom";
+    import type { Color } from "./custom";
 
     export function isColor(obj: unknown): obj is Color {
         const typedObj = obj as Color

--- a/tests/features/generated_type_guards_for_arrays_of_any.test.ts
+++ b/tests/features/generated_type_guards_for_arrays_of_any.test.ts
@@ -12,7 +12,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { Foo } from "./test";
+      import type { Foo } from "./test";
 
       export function isFoo(obj: unknown): obj is Foo {
           const typedObj = obj as Foo

--- a/tests/features/generated_type_guards_for_discriminated_unions.test.ts
+++ b/tests/features/generated_type_guards_for_discriminated_unions.test.ts
@@ -10,7 +10,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { X } from "./test";
+    import type { X } from "./test";
 
     export function isX(obj: unknown): obj is X {
         const typedObj = obj as X

--- a/tests/features/generated_type_guards_for_enums.test.ts
+++ b/tests/features/generated_type_guards_for_enums.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Types } from "./test";
+    import type { Types } from "./test";
 
     export function isTypes(obj: unknown): obj is Types {
         const typedObj = obj as Types

--- a/tests/features/generated_type_guards_for_intersection_type.test.ts
+++ b/tests/features/generated_type_guards_for_intersection_type.test.ts
@@ -10,7 +10,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { X } from "./test";
+    import type { X } from "./test";
 
     export function isX(obj: unknown): obj is X {
         const typedObj = obj as X

--- a/tests/features/generated_type_guards_for_nested_arrays.test.ts
+++ b/tests/features/generated_type_guards_for_nested_arrays.test.ts
@@ -14,7 +14,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-        import { Foo } from "./test";
+        import type { Foo } from "./test";
 
         export function isFoo(obj: unknown): obj is Foo {
             const typedObj = obj as Foo

--- a/tests/features/generated_type_guards_for_numeric_enums_in_optional_records.test.ts
+++ b/tests/features/generated_type_guards_for_numeric_enums_in_optional_records.test.ts
@@ -16,7 +16,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { Types, TestItem } from "./test";
+      import type { Types, TestItem } from "./test";
 
       export function isTypes(obj: unknown): obj is Types {
           const typedObj = obj as Types

--- a/tests/features/generates_tuples.test.ts
+++ b/tests/features/generates_tuples.test.ts
@@ -11,7 +11,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { A } from "./test";
+    import type { A } from "./test";
 
     export function isA(obj: unknown): obj is A {
         const typedObj = obj as A

--- a/tests/features/generates_type_guards_for_JSDoc_see_with_link_tag.test.ts
+++ b/tests/features/generates_type_guards_for_JSDoc_see_with_link_tag.test.ts
@@ -10,7 +10,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Bool } from "./test";
+    import type { Bool } from "./test";
 
     export function isBool(obj: unknown): obj is Bool {
         const typedObj = obj as Bool

--- a/tests/features/generates_type_guards_for_a_Pick_type.test.ts
+++ b/tests/features/generates_type_guards_for_a_Pick_type.test.ts
@@ -15,7 +15,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_an_object_literal_type.test.ts
+++ b/tests/features/generates_type_guards_for_an_object_literal_type.test.ts
@@ -12,7 +12,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_boolean.test.ts
+++ b/tests/features/generates_type_guards_for_boolean.test.ts
@@ -10,7 +10,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Bool } from "./test";
+    import type { Bool } from "./test";
 
     export function isBool(obj: unknown): obj is Bool {
         const typedObj = obj as Bool

--- a/tests/features/generates_type_guards_for_dynamic_object_keys,_including_when_mixed_with_static_keys.test.ts
+++ b/tests/features/generates_type_guards_for_dynamic_object_keys,_including_when_mixed_with_static_keys.test.ts
@@ -15,7 +15,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType } from "./test";
+      import type { TestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/generates_type_guards_for_empty_object_if_exportAll_is_true.test.ts
+++ b/tests/features/generates_type_guards_for_empty_object_if_exportAll_is_true.test.ts
@@ -9,7 +9,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Empty } from "./test";
+    import type { Empty } from "./test";
 
     export function isEmpty(obj: unknown): obj is Empty {
         const typedObj = obj as Empty

--- a/tests/features/generates_type_guards_for_interface_extending_object_type.test.ts
+++ b/tests/features/generates_type_guards_for_interface_extending_object_type.test.ts
@@ -16,7 +16,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_interface_extending_object_type_with_type_guard.test.ts
+++ b/tests/features/generates_type_guards_for_interface_extending_object_type_with_type_guard.test.ts
@@ -17,7 +17,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Bar, Foo } from "./test";
+    import type { Bar, Foo } from "./test";
 
     export function isBar(obj: unknown): obj is Bar {
         const typedObj = obj as Bar

--- a/tests/features/generates_type_guards_for_interface_extending_other_interface.test.ts
+++ b/tests/features/generates_type_guards_for_interface_extending_other_interface.test.ts
@@ -16,7 +16,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_interface_extending_other_interface_with_type_guard.test.ts
+++ b/tests/features/generates_type_guards_for_interface_extending_other_interface_with_type_guard.test.ts
@@ -17,7 +17,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Bar, Foo } from "./test";
+    import type { Bar, Foo } from "./test";
 
     export function isBar(obj: unknown): obj is Bar {
         const typedObj = obj as Bar

--- a/tests/features/generates_type_guards_for_interface_properties_with_numerical_names.test.ts
+++ b/tests/features/generates_type_guards_for_interface_properties_with_numerical_names.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_interface_property_with_empty_string_as_name.test.ts
+++ b/tests/features/generates_type_guards_for_interface_property_with_empty_string_as_name.test.ts
@@ -12,7 +12,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_interface_with_optional_field.test.ts
+++ b/tests/features/generates_type_guards_for_interface_with_optional_field.test.ts
@@ -14,7 +14,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_mapped_types.test.ts
+++ b/tests/features/generates_type_guards_for_mapped_types.test.ts
@@ -18,7 +18,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-     import { PropertyValueType, PropertyName, Foo } from "./test";
+     import type { PropertyValueType, PropertyName, Foo } from "./test";
 
      export function isPropertyValueType(obj: unknown): obj is PropertyValueType {
         const typedObj = obj as PropertyValueType

--- a/tests/features/generates_type_guards_for_nested_interface.test.ts
+++ b/tests/features/generates_type_guards_for_nested_interface.test.ts
@@ -16,7 +16,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_nested_interface_with_type_guard.test.ts
+++ b/tests/features/generates_type_guards_for_nested_interface_with_type_guard.test.ts
@@ -17,7 +17,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Bar, Foo } from "./test";
+    import type { Bar, Foo } from "./test";
 
     export function isBar(obj: unknown): obj is Bar {
         const typedObj = obj as Bar

--- a/tests/features/generates_type_guards_for_property_with_non_alphanumeric_name_.test.ts
+++ b/tests/features/generates_type_guards_for_property_with_non_alphanumeric_name_.test.ts
@@ -33,7 +33,7 @@ for (const propertyName of nonAlphanumericCharacterPropertyNames) {
     {
       'test.ts': null,
       'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo
@@ -59,7 +59,7 @@ for (const propertyName of nonAlphanumericCharacterPropertyNames) {
     {
       'test.ts': null,
       'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_record_types.test.ts
+++ b/tests/features/generates_type_guards_for_record_types.test.ts
@@ -11,7 +11,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType } from "./test";
+      import type { TestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/generates_type_guards_for_recursive_types.test.ts
+++ b/tests/features/generates_type_guards_for_recursive_types.test.ts
@@ -17,7 +17,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Branch1, Branch2, Branch3 } from "./test";
+    import type { Branch1, Branch2, Branch3 } from "./test";
 
     export function isBranch1(obj: unknown): obj is Branch1 {
         const typedObj = obj as Branch1

--- a/tests/features/generates_type_guards_for_simple_interface.test.ts
+++ b/tests/features/generates_type_guards_for_simple_interface.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_type_properties_with_numerical_names.test.ts
+++ b/tests/features/generates_type_guards_for_type_properties_with_numerical_names.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_for_type_property_with_empty_string_as_name.test.ts
+++ b/tests/features/generates_type_guards_for_type_property_with_empty_string_as_name.test.ts
@@ -12,7 +12,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/generates_type_guards_with_a_short_circuit.test.ts
+++ b/tests/features/generates_type_guards_with_a_short_circuit.test.ts
@@ -12,7 +12,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         if (DEBUG) return true

--- a/tests/features/imports_and_uses_generated_type_guard_if_the_type_is_used_in_another_file.test.ts
+++ b/tests/features/imports_and_uses_generated_type_guard_if_the_type_is_used_in_another_file.test.ts
@@ -20,8 +20,8 @@ testProcessProject(
     'test.ts': null,
     'test-list.ts': null,
     'test-list.guard.ts': `
-      import { isTestType } from "./test.guard";
-      import { TestTypeList } from "./test-list";
+      import type { isTestType } from "./test.guard";
+      import type { TestTypeList } from "./test-list";
 
       export function isTestTypeList(obj: unknown): obj is TestTypeList {
           const typedObj = obj as TestTypeList
@@ -34,7 +34,7 @@ testProcessProject(
       }
       `,
     'test.guard.ts': `
-        import { TestType } from "./test";
+        import type { TestType } from "./test";
 
         export function isTestType(obj: unknown): obj is TestType {
             const typedObj = obj as TestType

--- a/tests/features/prefixes_key_with_underscore_if_it_goes_unused.test.ts
+++ b/tests/features/prefixes_key_with_underscore_if_it_goes_unused.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType } from "./test";
+      import type { TestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/prefixes_value_with_underscore_if_it_goes_unused.test.ts
+++ b/tests/features/prefixes_value_with_underscore_if_it_goes_unused.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType } from "./test";
+      import type { TestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/show_debug_info.test.ts
+++ b/tests/features/show_debug_info.test.ts
@@ -21,7 +21,7 @@ testProcessProject(
   {
     [`foo/bar/test.ts`]: null,
     [`foo/bar/test.guard.ts`]: `
-    import { Foo, Bar } from "./test";
+    import type { Foo, Bar } from "./test";
 
     function evaluate(
       isCorrect: boolean,

--- a/tests/features/skips_checking_any_type_in_array.test.ts
+++ b/tests/features/skips_checking_any_type_in_array.test.ts
@@ -8,7 +8,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { A } from "./test";
+    import type { A } from "./test";
 
     export function isA(obj: unknown): obj is A {
         const typedObj = obj as A

--- a/tests/features/type_that_is_an_alias_to_an_interface_has_a_different_typeguard_name.test.ts
+++ b/tests/features/type_that_is_an_alias_to_an_interface_has_a_different_typeguard_name.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-      import { TestType, SecondaryTestType } from "./test";
+      import type { TestType, SecondaryTestType } from "./test";
 
       export function isTestType(obj: unknown): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/uses_correct_import_file_name_if_guard_file_is_renamed.test.ts
+++ b/tests/features/uses_correct_import_file_name_if_guard_file_is_renamed.test.ts
@@ -13,7 +13,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.debug.ts': `
-    import { Foo } from "./test";
+    import type { Foo } from "./test";
 
     export function isFoo(obj: unknown): obj is Foo {
         const typedObj = obj as Foo

--- a/tests/features/works_for_any_type.test.ts
+++ b/tests/features/works_for_any_type.test.ts
@@ -8,7 +8,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { A } from "./test";
+    import type { A } from "./test";
 
     export function isA(obj: unknown): obj is A {
         const typedObj = obj as A

--- a/tests/features/works_for_unknown_type.test.ts
+++ b/tests/features/works_for_unknown_type.test.ts
@@ -8,7 +8,7 @@ testProcessProject(
   {
     'test.ts': null,
     'test.guard.ts': `
-    import { A } from "./test";
+    import type { A } from "./test";
 
     export function isA(obj: unknown): obj is A {
         const typedObj = obj as A

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -68,7 +68,7 @@ const blueprints = [
 export interface Foo {
   target: InMemoryFileSystemHostOptions
 }`,
-    guardFile: `import { Foo } from "./ImportTest";
+    guardFile: `import type { Foo } from "./ImportTest";
 
 export function isFoo(obj: unknown): obj is Foo {
     const typedObj = obj as Foo
@@ -92,7 +92,7 @@ export function isFoo(obj: unknown): obj is Foo {
 export interface Foo {
   target: ResolutionHostFactory
 }`,
-    guardFile: `import { Foo } from "./ImportTest";
+    guardFile: `import type { Foo } from "./ImportTest";
 
 export function isFoo(obj: unknown): obj is Foo {
     const typedObj = obj as Foo
@@ -111,8 +111,8 @@ export function isFoo(obj: unknown): obj is Foo {
 export interface Foo {
   target: CompilerOptionsContainer
 }`,
-    guardFile: `import { CompilerOptionsContainer } from "@ts-morph/common";
-import { Foo } from "./ImportTest";
+    guardFile: `import type { CompilerOptionsContainer } from "@ts-morph/common";
+import type { Foo } from "./ImportTest";
 
 export function isFoo(obj: unknown): obj is Foo {
     const typedObj = obj as Foo
@@ -133,8 +133,8 @@ export interface Foo {
   res: TsConfigResolver,
   fs: InMemoryFileSystemHost
 }`,
-    guardFile: `import { CompilerOptionsContainer, TsConfigResolver, InMemoryFileSystemHost } from "@ts-morph/common";
-import { Foo } from "./ImportTest";
+    guardFile: `import type { CompilerOptionsContainer, TsConfigResolver, InMemoryFileSystemHost } from "@ts-morph/common";
+import type { Foo } from "./ImportTest";
 
 export function isFoo(obj: unknown): obj is Foo {
     const typedObj = obj as Foo
@@ -155,8 +155,8 @@ export function isFoo(obj: unknown): obj is Foo {
 export interface Foo {
   dir: Directory
 }`,
-    guardFile: `import { Directory } from "ts-morph";
-import { Foo } from "./ImportTest";
+    guardFile: `import type { Directory } from "ts-morph";
+import type { Foo } from "./ImportTest";
 
 export function isFoo(obj: unknown): obj is Foo {
     const typedObj = obj as Foo


### PR DESCRIPTION
Fixes #166

Type imports in guard files can be type-only imports, which some build tools need to know which import statements to drop for runtime.

Code change is only one line, but test changes involve all test guards using type-only imports.

Incompatible with typescript versions prior to 3.8, so this is probably a breaking change.