### PR TITLE
prettier should ignore node_modules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
vscode with the prettier extension installed freezes for about 30 seconds every time you format a file that imports from `ts-morph`.

This fixes that.