### PR TITLE
escape quoted property names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -400,7 +400,10 @@ To disable this warning, put comment "${suppressComment}" before the declaration
     const properties = [
       ...declaration.getProperties(),
       ...declaration.getMethods(),
-    ].map(p => ({ name: p.getName(), type: p.getType() }))
+    ].map(p => ({
+      name: p.getSymbol()?.getEscapedName() ?? p.getName(),
+      type: p.getType(),
+    }))
     conditions.push(
       ...propertiesConditions(
         varName,

--- a/tests/features/generates_type_guards_for_interface_property_with_quoted_strings_as_names.test.ts
+++ b/tests/features/generates_type_guards_for_interface_property_with_quoted_strings_as_names.test.ts
@@ -25,6 +25,5 @@ testProcessProject(
             typeof typedObj["double-quoted"] === "number"
         )
     }`,
-  },
-  { only: true }
+  }
 )

--- a/tests/features/generates_type_guards_for_interface_property_with_quoted_strings_as_names.test.ts
+++ b/tests/features/generates_type_guards_for_interface_property_with_quoted_strings_as_names.test.ts
@@ -1,0 +1,30 @@
+import { testProcessProject } from '../generate'
+
+testProcessProject(
+  'generates type guards for interface property with quoted strings as names',
+  {
+    'test.ts': `
+    /** @see {isFoo} ts-auto-guard:type-guard */
+    export interface Foo {
+      'single-quoted': number
+      "double-quoted": number
+    }`,
+  },
+  {
+    'test.ts': null,
+    'test.guard.ts': `
+    import { Foo } from "./test";
+
+    export function isFoo(obj: unknown): obj is Foo {
+        const typedObj = obj as Foo
+        return (
+            (typedObj !== null &&
+            typeof typedObj === "object" ||
+            typeof typedObj === "function") &&
+            typeof typedObj["single-quoted"] === "number" &&
+            typeof typedObj["double-quoted"] === "number"
+        )
+    }`,
+  },
+  { only: true }
+)


### PR DESCRIPTION
Property names in product types were not always bare, but sometimes had quote marks on them in the guard. Changed to use fully escaped form of the property name.

Fixes #212