### PR TITLE
ESLint Compatibility - Expand Variable Name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,7 @@ function arrayCondition(
   const indexIdentifier = `i${arrayDepth}`
   const elementPath = `${path}[\${${indexIdentifier}}]`
   const conditions = typeConditions(
-    'e',
+    'element',
     arrayType,
     addDependency,
     project,
@@ -288,7 +288,7 @@ function arrayCondition(
     : ''
   return ands(
     `Array.isArray(${varName})`,
-    `${varName}.every((e: any${secondArg}) =>\n${conditions}\n)`
+    `${varName}.every((element: any${secondArg}) =>\n${conditions}\n)`
   )
 }
 


### PR DESCRIPTION
Fully type out the variable name as the single character name is against the rules and will break projects with stricter ESLint settings.

Breaks the below ESLint rule:
https://eslint.org/docs/latest/rules/id-length