### PR TITLE
TSLint Compatibility - No Explicit Any

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -288,7 +288,7 @@ function arrayCondition(
     : ''
   return ands(
     `Array.isArray(${varName})`,
-    `${varName}.every((e: any${secondArg}) =>\n${conditions}\n)`
+    `${varName}.every((e: unknown{secondArg}) =>\n${conditions}\n)`
   )
 }
 


### PR DESCRIPTION
An explicit `any` is a way to "cheat" the TypeScript system. This allows for scenarios where all states of data are not accounted for and can lead to issues/security risks in code. Using "Any" in typescript is good for beta/prototype/lab code and should not be used in product as it fosters bad habits.

Please see the below for more info:
https://typescript-eslint.io/rules/no-explicit-any/