### PR TITLE
Check property existance before accessing it

### DIFF
--- a/tests/features/generated_type_guards_for_unions_with_disjoint_properties.test.ts
+++ b/tests/features/generated_type_guards_for_unions_with_disjoint_properties.test.ts
@@ -1,0 +1,32 @@
+import { testProcessProject } from '../generate'
+
+testProcessProject(
+  'generated type guards for unions with disjoint properties',
+  {
+    'test.ts': `
+    export type X = { key1: string } | { key2: number }
+    `,
+  },
+  {
+    'test.ts': null,
+    'test.guard.ts': `
+    import { X } from "./test";
+
+    export function isX(obj: unknown): obj is X {
+      const typedObj = obj as X
+      return (
+        ((typedObj !== null &&
+            typeof typedObj === "object" ||
+            typeof typedObj === "function") &&
+            "key1" in typedObj &&
+            typeof typedObj["key1"] === "string" ||
+            (typedObj !== null &&
+                typeof typedObj === "object" ||
+                typeof typedObj === "function") &&
+            "key2" in typedObj &&
+            typeof typedObj["key2"] === "number")
+      )
+    }`,
+  },
+  { options: { exportAll: true } }
+)

--- a/tests/features/generates_type_guards_for_simple_interface.test.ts
+++ b/tests/features/generates_type_guards_for_simple_interface.test.ts
@@ -21,7 +21,9 @@ testProcessProject(
             (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
+            "foo" in typedObj &&
             typeof typedObj["foo"] === "number" &&
+            "bar" in typedObj &&
             typeof typedObj["bar"] === "string"
         )
     }`,

--- a/tests/features/generates_type_guards_for_type_with_optional_field.test.ts
+++ b/tests/features/generates_type_guards_for_type_with_optional_field.test.ts
@@ -5,7 +5,7 @@ testProcessProject(
   {
     'test.ts': `
     /** @see {isFoo} ts-auto-guard:type-guard */
-    export interface Foo {
+    export type Foo {
       foo?: number,
       bar: number | undefined,
       baz?: number | undefined
@@ -22,17 +22,17 @@ testProcessProject(
         (typedObj !== null &&
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
-        ( !("foo" in typedObj) ||
+        (!("foo" in typedObj) ||
             "foo" in typedObj &&
             (typeof typedObj["foo"] === "undefined" ||
-                typeof typedObj["foo"] === "number" )) &&
+                typeof typedObj["foo"] === "number")) &&
         "bar" in typedObj &&
-        ( typeof typedObj["bar"] === "undefined" ||
-            typeof typedObj["bar"] === "number" ) &&
-        ( !("baz" in typedObj) ||
+        (typeof typedObj["bar"] === "undefined" ||
+            typeof typedObj["bar"] === "number") &&
+        (!("baz" in typedObj) ||
             "baz" in typedObj &&
             (typeof typedObj["baz"] === "undefined" ||
-                typeof typedObj["baz"] === "number" ))
+                typeof typedObj["baz"] === "number"))
       )
     }`,
   }


### PR DESCRIPTION
Closes https://github.com/rhys-vdw/ts-auto-guard/issues/213

As described in the issue above,

```ts
export interface SomeInterface {
  prop: { key1: string } | { key2: string };
}
```
in cases like the one shown, the following code is generated, which violates the noImplicitAny rule when accessing key1.
```ts
 typeof typedObj["prop"]["key1"] === "string"
```
- I have fixed this issue by ensuring that the property's existence is always checked before accessing it.
- For optional properties, I have implemented the condition to be either "nonexistent" or "existent and of the correct type".
  - It's important to note that ```a: number|undefined``` and ```a?: number``` are different.