### PR TITLE
Add MTS and CTS Support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ import {
 
 const GENERATED_WARNING = 'WARNING: Do not manually change this file.'
 
+/** Matches the supported file extensions of this project. */
+const fileExtensionRegex = /\.(ts|mts|cts|tsx|d\.ts)$/iu
+
 // -- Helpers --
 
 function reportError(message: string, ...args: unknown[]) {
@@ -85,7 +88,7 @@ function outFilePath(sourcePath: string, guardFileName: string): string {
 
   /** Name of the file to output the generated type guard. */
   const outPath = sourcePath.replace(
-    /\.(ts|mts|cts|tsx|d\.ts)$/u,
+    fileExtensionRegex,
     `.${guardFileName}.${cjsModuleMode ? 'cts' : esmModuleMode ? 'mts' : 'ts'}`
   )
 
@@ -1262,7 +1265,7 @@ export function processProject(
             .getFilePath()
             .split('/')
             .reverse()[0]
-            .replace(/\.(ts|mts|cts|tsx|d\.ts)$/, '')
+            .replace(fileExtensionRegex, '')
         const importStatement = `import * as ${options.importGuards} from "${relativeOutPath}${importExtension}";`
         const exportStatement = `export { ${options.importGuards} };`
         const { hasImport, hasExport, statements } = sourceFile

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,9 @@ function outFilePath(sourcePath: string, guardFileName: string): string {
 
   // Ensure that the new file name is not the same as the original file to prevent overwrite
   if (outPath === sourcePath) {
-    throw new Error('Internal Error: sourcePath and outFilePath are identical: ' + outPath)
+    throw new Error(
+      'Internal Error: sourcePath and outFilePath are identical: ' + outPath
+    )
   }
 
   // Return the output path to the caller

--- a/src/index.ts
+++ b/src/index.ts
@@ -1260,7 +1260,7 @@ export function processProject(
             .getFilePath()
             .split('/')
             .reverse()[0]
-            .replace(/\.(ts|tsx|d\.ts)$/, '')
+            .replace(/\.(ts|mts|cts|tsx|d\.ts)$/, '')
         const importStatement = `import * as ${options.importGuards} from "${relativeOutPath}${importExtension}";`
         const exportStatement = `export { ${options.importGuards} };`
         const { hasImport, hasExport, statements } = sourceFile

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,15 +70,31 @@ function typeToDependency(type: Type, addDependency: IAddDependency): void {
   addDependency(sourceFile, name, isDefault)
 }
 
-function outFilePath(sourcePath: string, guardFileName: string) {
+/**
+ * Computes the file name of the generated type guard.
+ * @param sourcePath Path of the file that is being analyzed for type information.
+ * @param guardFileName Suffix to append to the source file name to prevent conflict.
+ * @returns Computed file name of the newly generated type guard.
+ */
+function outFilePath(sourcePath: string, guardFileName: string): string {
+  /** Matches the file extension of the provided file if a MTS or CTS module mode is provided. */
+  const moduleFlagTest = /\.(mts|cts)$/u
+
+  /** Flag that indicates if a module mode was specified. */
+  const moduleMode = sourcePath.match(moduleFlagTest)
+
+  /** Name of the file to output the generated type guard. */
   const outPath = sourcePath.replace(
-    /\.(ts|tsx|d\.ts)$/,
-    `.${guardFileName}.ts`
+    /\.(ts|mts|cts|tsx|d\.ts)$/u,
+    `.${ guardFileName }.${ moduleMode ? moduleMode[0] : 'ts' }`
   )
-  if (outPath === sourcePath)
-    throw new Error(
-      'Internal Error: sourcePath and outFilePath are identical: ' + outPath
-    )
+
+  // Ensure that the new file name is not the same as the original file to prevent overwrite
+  if (outPath === sourcePath) {
+    throw new Error('Internal Error: sourcePath and outFilePath are identical: ' + outPath)
+  }
+
+  // Return the output path to the caller
   return outPath
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,16 +77,16 @@ function typeToDependency(type: Type, addDependency: IAddDependency): void {
  * @returns Computed file name of the newly generated type guard.
  */
 function outFilePath(sourcePath: string, guardFileName: string): string {
-  /** Matches the file extension of the provided file if a MTS or CTS module mode is provided. */
-  const moduleFlagTest = /\.(mts|cts)$/u
+  /** Flag that indicates if Common JS module mode was specified. */
+  const cjsModuleMode = sourcePath.endsWith('cts')
 
-  /** Flag that indicates if a module mode was specified. */
-  const moduleMode = sourcePath.match(moduleFlagTest)
+  /** Flag that indicates if ECMAScript Module mode was specified. */
+  const esmModuleMode = sourcePath.endsWith('mts')
 
   /** Name of the file to output the generated type guard. */
   const outPath = sourcePath.replace(
     /\.(ts|mts|cts|tsx|d\.ts)$/u,
-    `.${ guardFileName }.${ moduleMode ? moduleMode[0] : 'ts' }`
+    `.${guardFileName}.${cjsModuleMode ? 'cts' : esmModuleMode ? 'mts' : 'ts'}`
   )
 
   // Ensure that the new file name is not the same as the original file to prevent overwrite


### PR DESCRIPTION
This PR adds `MTS` and `CTS` support for file output and input so that projects that use mixed module modes are supported.

Currently when an MTS or CTS file is used, the following error is encountered:
`Internal Error: sourcePath and outFilePath are identical: ...`