### PR TITLE
feat: use unknown instead of any type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1055,7 +1055,7 @@ const evaluateFunction = `function evaluate(
   isCorrect: boolean,
   varName: string,
   expected: string,
-  actual: any
+  actual: unknown
 ): boolean {
   if (!isCorrect) {
     console.error(


### PR DESCRIPTION
When using the `--debug flag`, the generated file contains type `any` for the actual value that was received. This causes my linter or compiler to mark the file as red. Using `unknown` instead solves this and doesn't seem to affect functionality because `console.log` can handle unknown types.