### PR TITLE
Fix debug output for type guards of union types (fixes #353)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -277,19 +277,21 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -539,21 +541,23 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -645,9 +649,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -799,9 +803,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1018,9 +1022,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1191,9 +1195,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1803,9 +1807,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2559,9 +2563,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2650,9 +2654,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -2698,9 +2703,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2960,9 +2965,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3584,9 +3589,10 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4007,9 +4013,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,25 +220,27 @@ function typeUnionConditions(
   outFile: SourceFile,
   options: IProcessOptions
 ): string {
-  const conditions: string[] = []
-  conditions.push(
-    ...(types
-      .map(type =>
-        typeConditions(
-          varName,
-          type,
-          addDependency,
-          project,
-          path,
-          arrayDepth,
-          true,
-          records,
-          outFile,
-          options
-        )
+  const branchConditions = types
+    .map(type =>
+      typeConditions(
+        varName,
+        type,
+        addDependency,
+        project,
+        path,
+        arrayDepth,
+        true,
+        records,
+        outFile,
+        options
       )
-      .filter(v => v !== null) as string[])
-  )
+    )
+    .filter(v => v !== null) as string[]
+  // Silence nested evaluate() calls in non-matching branches so they don't log
+  // before a later branch matches.
+  const conditions = options.debug
+    ? branchConditions.map(c => `evaluateQuietly(() => (${c}))`)
+    : branchConditions
   return ors(...conditions)
 }
 
@@ -1051,13 +1053,22 @@ export interface IGenerateOptions {
   processOptions: Readonly<IProcessOptions>
 }
 
-const evaluateFunction = `function evaluate(
+const evaluateFunction = `let __evaluateQuietDepth = 0
+function evaluateQuietly<T>(fn: () => T): T {
+  __evaluateQuietDepth++
+  try {
+    return fn()
+  } finally {
+    __evaluateQuietDepth--
+  }
+}
+function evaluate(
   isCorrect: boolean,
   varName: string,
   expected: string,
   actual: any
 ): boolean {
-  if (!isCorrect) {
+  if (!isCorrect && __evaluateQuietDepth === 0) {
     console.error(
       \`\${varName} type mismatch, expected: \${expected}, found:\`,
       actual

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,12 +236,18 @@ function typeUnionConditions(
       )
     )
     .filter(v => v !== null) as string[]
-  // Silence nested evaluate() calls in non-matching branches so they don't log
-  // before a later branch matches.
-  const conditions = options.debug
-    ? branchConditions.map(c => `evaluateQuietly(() => (${c}))`)
-    : branchConditions
-  return ors(...conditions)
+  if (options.debug) {
+    let expectedType = types.map(t => t.getText()).join(' | ')
+    if (expectedType.indexOf('import') > -1) {
+      const standardizedCwd = FileUtils.standardizeSlashes(process.cwd())
+      expectedType = expectedType.replace(standardizedCwd, '.')
+    }
+    const branchFns = branchConditions.map(c => `() => (${c})`).join(', ')
+    return `evaluateUnion(\`${path}\`, ${JSON.stringify(
+      expectedType
+    )}, ${varName}, ${branchFns})`
+  }
+  return ors(...branchConditions)
 }
 
 function typeIntersectionConditions(
@@ -618,12 +624,19 @@ function reusedCondition(
   records: readonly IRecord[],
   outFile: SourceFile,
   addDependency: IAddDependency,
-  varName: string
+  varName: string,
+  path: string,
+  debug: boolean
 ): string | null {
   const record = records.find(x => x.typeDeclaration.getType() === type)
   if (record) {
     if (record.outFile !== outFile) {
       addDependency(record.outFile, record.guardName, false)
+    }
+    // Pass the caller's path as argumentName so the called guard's logs use
+    // the caller's location instead of its own default name.
+    if (debug) {
+      return `${record.guardName}(${varName}, \`${path}\`) as boolean`
     }
     return `${record.guardName}(${varName}) as boolean`
   }
@@ -642,7 +655,15 @@ function typeConditions(
   outFile: SourceFile,
   options: IProcessOptions
 ): string | null {
-  const reused = reusedCondition(type, records, outFile, addDependency, varName)
+  const reused = reusedCondition(
+    type,
+    records,
+    outFile,
+    addDependency,
+    varName,
+    path,
+    options.debug === true
+  )
   if (useGuard && reused) {
     return reused
   }
@@ -783,6 +804,9 @@ function propertyConditions(
     options
   )
   if (debug) {
+    // Union types self-report via evaluateUnion (inline) or the called
+    // guard's own evaluateUnion (named). Wrapping again would duplicate.
+    if (property.type.isUnion()) return conditions
     if (expectedType.indexOf('import') > -1) {
       const standardizedCwd = FileUtils.standardizeSlashes(process.cwd())
       expectedType = expectedType.replace(standardizedCwd, '.')
@@ -882,11 +906,13 @@ function indexSignatureConditions(
   }
   if (debug) {
     const cleanKeyReplacer = '${key.toString().replace(/"/g, \'\\\\"\')}'
-    const evaluation =
-      conditions &&
-      `evaluate(${conditions}, \`${path}["${cleanKeyReplacer}"]\`, ${JSON.stringify(
-        expectedType
-      )}, ${objName})`
+    // Union value types self-report; wrapping again would duplicate.
+    const evaluation = index.type.isUnion()
+      ? conditions
+      : conditions &&
+        `evaluate(${conditions}, \`${path}["${cleanKeyReplacer}"]\`, ${JSON.stringify(
+          expectedType
+        )}, ${objName})`
     const keyEvaluation =
       keyConditions &&
       `evaluate(${keyConditions}, \`${path} (key: "${cleanKeyReplacer}")\`, ${JSON.stringify(
@@ -994,16 +1020,9 @@ function generateTypeGuard(
     ? `if (${shortCircuitCondition}) return true\n`
     : ''
 
-  // A union body has no enclosing property-level evaluate to report a total
-  // mismatch, so wrap the body in evaluate ourselves.
-  const isUnionBody = typeDeclaration.getType().isUnion()
-  const returnExpression =
-    debug && isUnionBody && conditions
-      ? `evaluate(${conditions}, argumentName, ${JSON.stringify(
-          typeName
-        )}, ${signatureObjName})`
-      : conditions || true
-  const functionBody = `const ${innerObjName} = ${signatureObjName} as ${typeName}\nreturn (\n${returnExpression}\n)\n}\n`
+  const functionBody = `const ${innerObjName} = ${signatureObjName} as ${typeName}\nreturn (\n${
+    conditions || true
+  }\n)\n}\n`
 
   return [signature, shortCircuit, functionBody].join('')
 }
@@ -1060,28 +1079,28 @@ export interface IGenerateOptions {
   processOptions: Readonly<IProcessOptions>
 }
 
-const evaluateFunction = `let __evaluateQuietDepth = 0
-function evaluateQuietly<T>(fn: () => T): T {
-  __evaluateQuietDepth++
-  try {
-    return fn()
-  } finally {
-    __evaluateQuietDepth--
-  }
-}
-function evaluate(
-  isCorrect: boolean,
-  varName: string,
-  expected: string,
-  actual: any
-): boolean {
-  if (!isCorrect && __evaluateQuietDepth === 0) {
-    console.error(
-      \`\${varName} type mismatch, expected: \${expected}, found:\`,
-      actual
-    )
+const evaluateFunction = `let __evaluateBuffer: Array<unknown[]> | null = null
+function evaluate(isCorrect: boolean, varName: string, expected: string, actual: any): boolean {
+  if (!isCorrect) {
+    const args: unknown[] = [\`\${varName} type mismatch, expected: \${expected}, found:\`, actual]
+    __evaluateBuffer ? __evaluateBuffer.push(args) : console.error(...args)
   }
   return isCorrect
+}
+function evaluateUnion(varName: string, expected: string, actual: any, ...branches: Array<() => boolean>): boolean {
+  const previous = __evaluateBuffer
+  const collected: Array<unknown[]> = []
+  for (const fn of branches) {
+    const branchBuffer: Array<unknown[]> = []
+    __evaluateBuffer = branchBuffer
+    if (fn()) { __evaluateBuffer = previous; return true }
+    collected.push(...branchBuffer)
+  }
+  __evaluateBuffer = previous
+  collected.push([\`\${varName} type mismatch, expected: \${expected}, found:\`, actual])
+  if (previous) collected.forEach(a => previous.push(a))
+  else collected.forEach(a => console.error(...a))
+  return false
 }\n`
 
 export async function generate({

--- a/src/index.ts
+++ b/src/index.ts
@@ -994,9 +994,16 @@ function generateTypeGuard(
     ? `if (${shortCircuitCondition}) return true\n`
     : ''
 
-  const functionBody = `const ${innerObjName} = ${signatureObjName} as ${typeName}\nreturn (\n${
-    conditions || true
-  }\n)\n}\n`
+  // A union body has no enclosing property-level evaluate to report a total
+  // mismatch, so wrap the body in evaluate ourselves.
+  const isUnionBody = typeDeclaration.getType().isUnion()
+  const returnExpression =
+    debug && isUnionBody && conditions
+      ? `evaluate(${conditions}, argumentName, ${JSON.stringify(
+          typeName
+        )}, ${signatureObjName})`
+      : conditions || true
+  const functionBody = `const ${innerObjName} = ${signatureObjName} as ${typeName}\nreturn (\n${returnExpression}\n)\n}\n`
 
   return [signature, shortCircuit, functionBody].join('')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1079,15 +1079,15 @@ export interface IGenerateOptions {
   processOptions: Readonly<IProcessOptions>
 }
 
-const evaluateFunction = `let __evaluateBuffer: Array<unknown[]> | null = null
-function evaluate(isCorrect: boolean, varName: string, expected: string, actual: any): boolean {
+const evaluateBufferDecl = `let __evaluateBuffer: Array<unknown[]> | null = null\n`
+const evaluateFn = `function evaluate(isCorrect: boolean, varName: string, expected: string, actual: any): boolean {
   if (!isCorrect) {
     const args: unknown[] = [\`\${varName} type mismatch, expected: \${expected}, found:\`, actual]
     __evaluateBuffer ? __evaluateBuffer.push(args) : console.error(...args)
   }
   return isCorrect
-}
-function evaluateUnion(varName: string, expected: string, actual: any, ...branches: Array<() => boolean>): boolean {
+}\n`
+const evaluateUnionFn = `function evaluateUnion(varName: string, expected: string, actual: any, ...branches: Array<() => boolean>): boolean {
   const previous = __evaluateBuffer
   const collected: Array<unknown[]> = []
   for (const fn of branches) {
@@ -1102,6 +1102,17 @@ function evaluateUnion(varName: string, expected: string, actual: any, ...branch
   else collected.forEach(a => console.error(...a))
   return false
 }\n`
+
+function buildEvaluateHelpers(body: string): string {
+  const usesEvaluate = body.includes('evaluate(')
+  const usesEvaluateUnion = body.includes('evaluateUnion(')
+  if (!usesEvaluate && !usesEvaluateUnion) return ''
+  return (
+    evaluateBufferDecl +
+    (usesEvaluate ? evaluateFn : '') +
+    (usesEvaluateUnion ? evaluateUnionFn : '')
+  )
+}
 
 export async function generate({
   paths = [],
@@ -1231,7 +1242,8 @@ export function processProject(
 
     if (functions.length > 0) {
       if (options.debug) {
-        functions.unshift(evaluateFunction)
+        const helpers = buildEvaluateHelpers(functions.join('\n'))
+        if (helpers) functions.unshift(helpers)
       }
 
       outFile.addStatements(functions.join('\n'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { FileUtils } from '@ts-morph/common'
 import {
   EnumDeclaration,
   ExportableNode,
@@ -25,6 +24,12 @@ const fileExtensionRegex = /\.(ts|mts|cts|tsx|d\.ts)$/iu
 
 function reportError(message: string, ...args: unknown[]) {
   console.error(`ERROR: ${message}`, ...args)
+}
+
+// Strip the project root from absolute paths so debug output stays OS-agnostic
+function relativizeImports(text: string, outFile: SourceFile): string {
+  const projectDir = outFile.getProject().getFileSystem().getCurrentDirectory()
+  return projectDir === '/' ? text : text.replaceAll(projectDir, '.')
 }
 
 function lowerFirst(s: string): string {
@@ -237,11 +242,10 @@ function typeUnionConditions(
     )
     .filter(v => v !== null) as string[]
   if (options.debug) {
-    let expectedType = types.map(t => t.getText()).join(' | ')
-    if (expectedType.indexOf('import') > -1) {
-      const standardizedCwd = FileUtils.standardizeSlashes(process.cwd())
-      expectedType = expectedType.replace(standardizedCwd, '.')
-    }
+    const expectedType = relativizeImports(
+      types.map(t => t.getText()).join(' | '),
+      outFile
+    )
     const branchFns = branchConditions.map(c => `() => (${c})`).join(', ')
     return `evaluateUnion(\`${path}\`, ${JSON.stringify(
       expectedType
@@ -790,7 +794,6 @@ function propertyConditions(
   const varName = `${objName}["${strippedName}"]`
   const propertyPath = `${path}["${strippedName}"]`
 
-  let expectedType = property.type.getText()
   const conditions = typeConditions(
     varName,
     property.type,
@@ -807,10 +810,7 @@ function propertyConditions(
     // Union types self-report via evaluateUnion (inline) or the called
     // guard's own evaluateUnion (named). Wrapping again would duplicate.
     if (property.type.isUnion()) return conditions
-    if (expectedType.indexOf('import') > -1) {
-      const standardizedCwd = FileUtils.standardizeSlashes(process.cwd())
-      expectedType = expectedType.replace(standardizedCwd, '.')
-    }
+    const expectedType = relativizeImports(property.type.getText(), outFile)
     return (
       conditions &&
       `evaluate(${conditions}, \`${propertyPath}\`, ${JSON.stringify(
@@ -884,7 +884,7 @@ function indexSignatureConditions(
   options: IProcessOptions
 ): string | null {
   const { debug } = options
-  const expectedType = index.type.getText()
+  const expectedType = relativizeImports(index.type.getText(), outFile)
   const conditions = typeConditions(
     objName,
     index.type,

--- a/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
+++ b/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
@@ -150,9 +150,20 @@ test(
         isFooOrBar(notFooOrBar),
         'isFooOrBar should return false for a value matching neither branch'
       )
+      const flat = errors.map(args =>
+        args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
+      )
       t.ok(
-        errors.length > 0,
-        'console.error should be called when isFooOrBar returns false'
+        flat.some(s => s.includes('"foo"')),
+        'should surface the Foo branch failure (kind !== "foo")'
+      )
+      t.ok(
+        flat.some(s => s.includes('"bar"')),
+        'should surface the Bar branch failure (kind !== "bar")'
+      )
+      t.ok(
+        flat.some(s => s.includes('Foo') && s.includes('Bar') && s.includes('|')),
+        'should surface the union-level summary'
       )
     } finally {
       console.error = originalError

--- a/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
+++ b/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
@@ -1,0 +1,89 @@
+import test from 'tape'
+import { Project } from 'ts-morph'
+import { processProject } from '../../src'
+
+test(
+  'debug output is not printed when a union of own-guarded components matches',
+  t => {
+    const project = new Project({
+      skipAddingFilesFromTsConfig: true,
+      compilerOptions: {
+        strict: true,
+        target: 8 /* ES2021 */,
+        module: 1 /* CommonJS */,
+        esModuleInterop: true,
+      },
+      useInMemoryFileSystem: true,
+    })
+
+    project.createSourceFile(
+      'test.ts',
+      `
+      /** @see {isFoo} ts-auto-guard:type-guard */
+      export interface Foo {
+        kind: 'foo'
+        foo: number
+      }
+
+      /** @see {isBar} ts-auto-guard:type-guard */
+      export interface Bar {
+        kind: 'bar'
+        bar: string
+      }
+
+      /** @see {isFooOrBar} ts-auto-guard:type-guard */
+      export type FooOrBar = Foo | Bar
+      `
+    )
+
+    processProject(project, { debug: true })
+
+    const guardFile = project.getSourceFileOrThrow('test.guard.ts')
+    const emittedJs = guardFile.getEmitOutput().getOutputFiles()[0].getText()
+
+    const moduleObj: { exports: Record<string, unknown> } = { exports: {} }
+    // Stub require: the imports from "./test" are type-only and erased.
+    const requireStub = () => ({})
+    new Function('exports', 'require', 'module', emittedJs)(
+      moduleObj.exports,
+      requireStub,
+      moduleObj
+    )
+
+    const isFooOrBar = moduleObj.exports.isFooOrBar as (
+      obj: unknown
+    ) => boolean
+
+    const errors: unknown[][] = []
+    const originalError = console.error
+    console.error = (...args: unknown[]) => {
+      errors.push(args)
+    }
+    try {
+      const validBar: unknown = { kind: 'bar', bar: 'hello' }
+      t.true(
+        isFooOrBar(validBar),
+        'isFooOrBar should return true for a valid Bar'
+      )
+      t.deepEqual(
+        errors.splice(0),
+        [],
+        'no console.error output when isFooOrBar returns true for a Bar'
+      )
+
+      const validFoo: unknown = { kind: 'foo', foo: 42 }
+      t.true(
+        isFooOrBar(validFoo),
+        'isFooOrBar should return true for a valid Foo'
+      )
+      t.deepEqual(
+        errors.splice(0),
+        [],
+        'no console.error output when isFooOrBar returns true for a Foo'
+      )
+    } finally {
+      console.error = originalError
+    }
+    t.end()
+  }
+)

--- a/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
+++ b/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
@@ -2,23 +2,21 @@ import test from 'tape'
 import { Project } from 'ts-morph'
 import { processProject } from '../../src'
 
-test(
-  'debug output is not printed when a union of own-guarded components matches',
-  t => {
-    const project = new Project({
-      skipAddingFilesFromTsConfig: true,
-      compilerOptions: {
-        strict: true,
-        target: 8 /* ES2021 */,
-        module: 1 /* CommonJS */,
-        esModuleInterop: true,
-      },
-      useInMemoryFileSystem: true,
-    })
+test('debug output is not printed when a union of own-guarded components matches', t => {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: {
+      strict: true,
+      target: 8 /* ES2021 */,
+      module: 1 /* CommonJS */,
+      esModuleInterop: true,
+    },
+    useInMemoryFileSystem: true,
+  })
 
-    project.createSourceFile(
-      'test.ts',
-      `
+  project.createSourceFile(
+    'test.ts',
+    `
       /** @see {isFoo} ts-auto-guard:type-guard */
       export interface Foo {
         kind: 'foo'
@@ -34,77 +32,72 @@ test(
       /** @see {isFooOrBar} ts-auto-guard:type-guard */
       export type FooOrBar = Foo | Bar
       `
-    )
+  )
 
-    processProject(project, { debug: true })
+  processProject(project, { debug: true })
 
-    const guardFile = project.getSourceFileOrThrow('test.guard.ts')
-    const emittedJs = guardFile.getEmitOutput().getOutputFiles()[0].getText()
+  const guardFile = project.getSourceFileOrThrow('test.guard.ts')
+  const emittedJs = guardFile.getEmitOutput().getOutputFiles()[0].getText()
 
-    const moduleObj: { exports: Record<string, unknown> } = { exports: {} }
-    // Stub require: the imports from "./test" are type-only and erased.
-    const requireStub = () => ({})
-    new Function('exports', 'require', 'module', emittedJs)(
-      moduleObj.exports,
-      requireStub,
-      moduleObj
-    )
+  const moduleObj: { exports: Record<string, unknown> } = { exports: {} }
+  // Stub require: the imports from "./test" are type-only and erased.
+  const requireStub = () => ({})
+  new Function('exports', 'require', 'module', emittedJs)(
+    moduleObj.exports,
+    requireStub,
+    moduleObj
+  )
 
-    const isFooOrBar = moduleObj.exports.isFooOrBar as (
-      obj: unknown
-    ) => boolean
+  const isFooOrBar = moduleObj.exports.isFooOrBar as (obj: unknown) => boolean
 
-    const errors: unknown[][] = []
-    const originalError = console.error
-    console.error = (...args: unknown[]) => {
-      errors.push(args)
-    }
-    try {
-      const validBar: unknown = { kind: 'bar', bar: 'hello' }
-      t.true(
-        isFooOrBar(validBar),
-        'isFooOrBar should return true for a valid Bar'
-      )
-      t.deepEqual(
-        errors.splice(0),
-        [],
-        'no console.error output when isFooOrBar returns true for a Bar'
-      )
-
-      const validFoo: unknown = { kind: 'foo', foo: 42 }
-      t.true(
-        isFooOrBar(validFoo),
-        'isFooOrBar should return true for a valid Foo'
-      )
-      t.deepEqual(
-        errors.splice(0),
-        [],
-        'no console.error output when isFooOrBar returns true for a Foo'
-      )
-    } finally {
-      console.error = originalError
-    }
-    t.end()
+  const errors: unknown[][] = []
+  const originalError = console.error
+  console.error = (...args: unknown[]) => {
+    errors.push(args)
   }
-)
+  try {
+    const validBar: unknown = { kind: 'bar', bar: 'hello' }
+    t.true(
+      isFooOrBar(validBar),
+      'isFooOrBar should return true for a valid Bar'
+    )
+    t.deepEqual(
+      errors.splice(0),
+      [],
+      'no console.error output when isFooOrBar returns true for a Bar'
+    )
 
-test(
-  'debug output is printed when a union of own-guarded components does not match',
-  t => {
-    const project = new Project({
-      skipAddingFilesFromTsConfig: true,
-      compilerOptions: {
-        strict: true,
-        target: 8 /* ES2021 */,
-        module: 1 /* CommonJS */,
-        esModuleInterop: true,
-      },
-      useInMemoryFileSystem: true,
-    })
+    const validFoo: unknown = { kind: 'foo', foo: 42 }
+    t.true(
+      isFooOrBar(validFoo),
+      'isFooOrBar should return true for a valid Foo'
+    )
+    t.deepEqual(
+      errors.splice(0),
+      [],
+      'no console.error output when isFooOrBar returns true for a Foo'
+    )
+  } finally {
+    console.error = originalError
+  }
+  t.end()
+})
 
-    project.createSourceFile(
-      'test.ts',
-      `
+test('debug output is printed when a union of own-guarded components does not match', t => {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: {
+      strict: true,
+      target: 8 /* ES2021 */,
+      module: 1 /* CommonJS */,
+      esModuleInterop: true,
+    },
+    useInMemoryFileSystem: true,
+  })
+
+  project.createSourceFile(
+    'test.ts',
+    `
       /** @see {isFoo} ts-auto-guard:type-guard */
       export interface Foo {
         kind: 'foo'
@@ -120,54 +113,51 @@ test(
       /** @see {isFooOrBar} ts-auto-guard:type-guard */
       export type FooOrBar = Foo | Bar
       `
-    )
+  )
 
-    processProject(project, { debug: true })
+  processProject(project, { debug: true })
 
-    const guardFile = project.getSourceFileOrThrow('test.guard.ts')
-    const emittedJs = guardFile.getEmitOutput().getOutputFiles()[0].getText()
+  const guardFile = project.getSourceFileOrThrow('test.guard.ts')
+  const emittedJs = guardFile.getEmitOutput().getOutputFiles()[0].getText()
 
-    const moduleObj: { exports: Record<string, unknown> } = { exports: {} }
-    const requireStub = () => ({})
-    new Function('exports', 'require', 'module', emittedJs)(
-      moduleObj.exports,
-      requireStub,
-      moduleObj
-    )
+  const moduleObj: { exports: Record<string, unknown> } = { exports: {} }
+  const requireStub = () => ({})
+  new Function('exports', 'require', 'module', emittedJs)(
+    moduleObj.exports,
+    requireStub,
+    moduleObj
+  )
 
-    const isFooOrBar = moduleObj.exports.isFooOrBar as (
-      obj: unknown
-    ) => boolean
+  const isFooOrBar = moduleObj.exports.isFooOrBar as (obj: unknown) => boolean
 
-    const errors: unknown[][] = []
-    const originalError = console.error
-    console.error = (...args: unknown[]) => {
-      errors.push(args)
-    }
-    try {
-      const notFooOrBar: unknown = { kind: 'baz', baz: true }
-      t.false(
-        isFooOrBar(notFooOrBar),
-        'isFooOrBar should return false for a value matching neither branch'
-      )
-      const flat = errors.map(args =>
-        args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
-      )
-      t.ok(
-        flat.some(s => s.includes('"foo"')),
-        'should surface the Foo branch failure (kind !== "foo")'
-      )
-      t.ok(
-        flat.some(s => s.includes('"bar"')),
-        'should surface the Bar branch failure (kind !== "bar")'
-      )
-      t.ok(
-        flat.some(s => s.includes('Foo') && s.includes('Bar') && s.includes('|')),
-        'should surface the union-level summary'
-      )
-    } finally {
-      console.error = originalError
-    }
-    t.end()
+  const errors: unknown[][] = []
+  const originalError = console.error
+  console.error = (...args: unknown[]) => {
+    errors.push(args)
   }
-)
+  try {
+    const notFooOrBar: unknown = { kind: 'baz', baz: true }
+    t.false(
+      isFooOrBar(notFooOrBar),
+      'isFooOrBar should return false for a value matching neither branch'
+    )
+    const flat = errors.map(args =>
+      args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')
+    )
+    t.ok(
+      flat.some(s => s.includes('"foo"')),
+      'should surface the Foo branch failure (kind !== "foo")'
+    )
+    t.ok(
+      flat.some(s => s.includes('"bar"')),
+      'should surface the Bar branch failure (kind !== "bar")'
+    )
+    t.ok(
+      flat.some(s => s.includes('Foo') && s.includes('Bar') && s.includes('|')),
+      'should surface the union-level summary'
+    )
+  } finally {
+    console.error = originalError
+  }
+  t.end()
+})

--- a/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
+++ b/tests/features/debug_output_for_union_with_own_guarded_components.test.ts
@@ -87,3 +87,76 @@ test(
     t.end()
   }
 )
+
+test(
+  'debug output is printed when a union of own-guarded components does not match',
+  t => {
+    const project = new Project({
+      skipAddingFilesFromTsConfig: true,
+      compilerOptions: {
+        strict: true,
+        target: 8 /* ES2021 */,
+        module: 1 /* CommonJS */,
+        esModuleInterop: true,
+      },
+      useInMemoryFileSystem: true,
+    })
+
+    project.createSourceFile(
+      'test.ts',
+      `
+      /** @see {isFoo} ts-auto-guard:type-guard */
+      export interface Foo {
+        kind: 'foo'
+        foo: number
+      }
+
+      /** @see {isBar} ts-auto-guard:type-guard */
+      export interface Bar {
+        kind: 'bar'
+        bar: string
+      }
+
+      /** @see {isFooOrBar} ts-auto-guard:type-guard */
+      export type FooOrBar = Foo | Bar
+      `
+    )
+
+    processProject(project, { debug: true })
+
+    const guardFile = project.getSourceFileOrThrow('test.guard.ts')
+    const emittedJs = guardFile.getEmitOutput().getOutputFiles()[0].getText()
+
+    const moduleObj: { exports: Record<string, unknown> } = { exports: {} }
+    const requireStub = () => ({})
+    new Function('exports', 'require', 'module', emittedJs)(
+      moduleObj.exports,
+      requireStub,
+      moduleObj
+    )
+
+    const isFooOrBar = moduleObj.exports.isFooOrBar as (
+      obj: unknown
+    ) => boolean
+
+    const errors: unknown[][] = []
+    const originalError = console.error
+    console.error = (...args: unknown[]) => {
+      errors.push(args)
+    }
+    try {
+      const notFooOrBar: unknown = { kind: 'baz', baz: true }
+      t.false(
+        isFooOrBar(notFooOrBar),
+        'isFooOrBar should return false for a value matching neither branch'
+      )
+      t.ok(
+        errors.length > 0,
+        'console.error should be called when isFooOrBar returns false'
+      )
+    } finally {
+      console.error = originalError
+    }
+    t.end()
+  }
+)

--- a/tests/features/generates_type_guards_for_record_types_in_debug_mode.test.ts
+++ b/tests/features/generates_type_guards_for_record_types_in_debug_mode.test.ts
@@ -13,13 +13,22 @@ testProcessProject(
     'test.guard.ts': `
       import { TestType } from "./test";
   
+      let __evaluateQuietDepth = 0
+      function evaluateQuietly<T>(fn: () => T): T {
+        __evaluateQuietDepth++
+        try {
+          return fn()
+        } finally {
+          __evaluateQuietDepth--
+        }
+      }
       function evaluate(
         isCorrect: boolean,
         varName: string,
         expected: string,
         actual: any
       ): boolean {
-        if (!isCorrect) {
+        if (!isCorrect && __evaluateQuietDepth === 0) {
           console.error(
             \`\${varName} type mismatch, expected: \${expected}, found:\`,
                         actual

--- a/tests/features/generates_type_guards_for_record_types_in_debug_mode.test.ts
+++ b/tests/features/generates_type_guards_for_record_types_in_debug_mode.test.ts
@@ -13,28 +13,28 @@ testProcessProject(
     'test.guard.ts': `
       import { TestType } from "./test";
   
-      let __evaluateQuietDepth = 0
-      function evaluateQuietly<T>(fn: () => T): T {
-        __evaluateQuietDepth++
-        try {
-          return fn()
-        } finally {
-          __evaluateQuietDepth--
-        }
-      }
-      function evaluate(
-        isCorrect: boolean,
-        varName: string,
-        expected: string,
-        actual: any
-      ): boolean {
-        if (!isCorrect && __evaluateQuietDepth === 0) {
-          console.error(
-            \`\${varName} type mismatch, expected: \${expected}, found:\`,
-                        actual
-            )
+      let __evaluateBuffer: Array<unknown[]> | null = null
+      function evaluate(isCorrect: boolean, varName: string, expected: string, actual: any): boolean {
+        if (!isCorrect) {
+          const args: unknown[] = [\`\${varName} type mismatch, expected: \${expected}, found:\`, actual]
+          __evaluateBuffer ? __evaluateBuffer.push(args) : console.error(...args)
         }
         return isCorrect
+      }
+      function evaluateUnion(varName: string, expected: string, actual: any, ...branches: Array<() => boolean>): boolean {
+        const previous = __evaluateBuffer
+        const collected: Array<unknown[]> = []
+        for (const fn of branches) {
+          const branchBuffer: Array<unknown[]> = []
+          __evaluateBuffer = branchBuffer
+          if (fn()) { __evaluateBuffer = previous; return true }
+          collected.push(...branchBuffer)
+        }
+        __evaluateBuffer = previous
+        collected.push([\`\${varName} type mismatch, expected: \${expected}, found:\`, actual])
+        if (previous) collected.forEach(a => previous.push(a))
+        else collected.forEach(a => console.error(...a))
+        return false
       }
 
       export function isTestType(obj: unknown, argumentName: string = "testType"): obj is TestType {

--- a/tests/features/generates_type_guards_for_record_types_in_debug_mode.test.ts
+++ b/tests/features/generates_type_guards_for_record_types_in_debug_mode.test.ts
@@ -21,21 +21,6 @@ testProcessProject(
         }
         return isCorrect
       }
-      function evaluateUnion(varName: string, expected: string, actual: any, ...branches: Array<() => boolean>): boolean {
-        const previous = __evaluateBuffer
-        const collected: Array<unknown[]> = []
-        for (const fn of branches) {
-          const branchBuffer: Array<unknown[]> = []
-          __evaluateBuffer = branchBuffer
-          if (fn()) { __evaluateBuffer = previous; return true }
-          collected.push(...branchBuffer)
-        }
-        __evaluateBuffer = previous
-        collected.push([\`\${varName} type mismatch, expected: \${expected}, found:\`, actual])
-        if (previous) collected.forEach(a => previous.push(a))
-        else collected.forEach(a => console.error(...a))
-        return false
-      }
 
       export function isTestType(obj: unknown, argumentName: string = "testType"): obj is TestType {
           const typedObj = obj as TestType

--- a/tests/features/show_debug_info.test.ts
+++ b/tests/features/show_debug_info.test.ts
@@ -23,13 +23,22 @@ testProcessProject(
     [`foo/bar/test.guard.ts`]: `
     import { Foo, Bar } from "./test";
 
+    let __evaluateQuietDepth = 0
+    function evaluateQuietly<T>(fn: () => T): T {
+      __evaluateQuietDepth++
+      try {
+        return fn()
+      } finally {
+        __evaluateQuietDepth--
+      }
+    }
     function evaluate(
       isCorrect: boolean,
       varName: string,
       expected: string,
       actual: any
     ): boolean {
-      if (!isCorrect) {
+      if (!isCorrect && __evaluateQuietDepth === 0) {
         console.error(
           \`\${varName} type mismatch, expected: \${expected}, found:\`,
                       actual

--- a/tests/features/show_debug_info.test.ts
+++ b/tests/features/show_debug_info.test.ts
@@ -31,21 +31,6 @@ testProcessProject(
       }
       return isCorrect
     }
-    function evaluateUnion(varName: string, expected: string, actual: any, ...branches: Array<() => boolean>): boolean {
-      const previous = __evaluateBuffer
-      const collected: Array<unknown[]> = []
-      for (const fn of branches) {
-        const branchBuffer: Array<unknown[]> = []
-        __evaluateBuffer = branchBuffer
-        if (fn()) { __evaluateBuffer = previous; return true }
-        collected.push(...branchBuffer)
-      }
-      __evaluateBuffer = previous
-      collected.push([\`\${varName} type mismatch, expected: \${expected}, found:\`, actual])
-      if (previous) collected.forEach(a => previous.push(a))
-      else collected.forEach(a => console.error(...a))
-      return false
-    }
 
     export function isFoo(obj: unknown, argumentName: string = "foo"): obj is Foo {
       const typedObj = obj as Foo

--- a/tests/features/show_debug_info.test.ts
+++ b/tests/features/show_debug_info.test.ts
@@ -23,28 +23,28 @@ testProcessProject(
     [`foo/bar/test.guard.ts`]: `
     import { Foo, Bar } from "./test";
 
-    let __evaluateQuietDepth = 0
-    function evaluateQuietly<T>(fn: () => T): T {
-      __evaluateQuietDepth++
-      try {
-        return fn()
-      } finally {
-        __evaluateQuietDepth--
-      }
-    }
-    function evaluate(
-      isCorrect: boolean,
-      varName: string,
-      expected: string,
-      actual: any
-    ): boolean {
-      if (!isCorrect && __evaluateQuietDepth === 0) {
-        console.error(
-          \`\${varName} type mismatch, expected: \${expected}, found:\`,
-                      actual
-          )
+    let __evaluateBuffer: Array<unknown[]> | null = null
+    function evaluate(isCorrect: boolean, varName: string, expected: string, actual: any): boolean {
+      if (!isCorrect) {
+        const args: unknown[] = [\`\${varName} type mismatch, expected: \${expected}, found:\`, actual]
+        __evaluateBuffer ? __evaluateBuffer.push(args) : console.error(...args)
       }
       return isCorrect
+    }
+    function evaluateUnion(varName: string, expected: string, actual: any, ...branches: Array<() => boolean>): boolean {
+      const previous = __evaluateBuffer
+      const collected: Array<unknown[]> = []
+      for (const fn of branches) {
+        const branchBuffer: Array<unknown[]> = []
+        __evaluateBuffer = branchBuffer
+        if (fn()) { __evaluateBuffer = previous; return true }
+        collected.push(...branchBuffer)
+      }
+      __evaluateBuffer = previous
+      collected.push([\`\${varName} type mismatch, expected: \${expected}, found:\`, actual])
+      if (previous) collected.forEach(a => previous.push(a))
+      else collected.forEach(a => console.error(...a))
+      return false
     }
 
     export function isFoo(obj: unknown, argumentName: string = "foo"): obj is Foo {
@@ -54,10 +54,10 @@ testProcessProject(
           typeof typedObj === "object" ||
           typeof typedObj === "function") &&
           evaluate(typeof typedObj["foo"] === "number", \`\${argumentName}["foo"]\`, "number", typedObj["foo"]) &&
-          evaluate(isBar(typedObj["bar"]) as boolean, \`\${argumentName}["bar"]\`, "import(\\"/foo/bar/test\\").Bar", typedObj["bar"]) &&
+          evaluate(isBar(typedObj["bar"], \`\${argumentName}["bar"]\`) as boolean, \`\${argumentName}["bar"]\`, "import(\\"/foo/bar/test\\").Bar", typedObj["bar"]) &&
           evaluate(Array.isArray(typedObj["bars"]) &&
-            typedObj["bars"].every((e: any) =>
-              isBar(e) as boolean
+            typedObj["bars"].every((e: any, i0: number) =>
+              isBar(e, \`\${argumentName}["bars"][\${i0}]\`) as boolean
             ), \`\${argumentName}["bars"]\`, "import(\\"/foo/bar/test\\").Bar[]", typedObj["bars"])
         )
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
Type guards for union types follow the form
```ts
function isFooOrBar(obj, argumentName = "fooOrBar") {
    const typedObj = obj;
    return isFoo(typedObj) || isBar(typedObj);
}
```
When `isFoo` returns false, it also reports an error.
We need to distinguish calls to type guards from user-space and internal calls to delay error reporting until we know that the whole type guard failed.

I sketched a solution by introducing global state, the `__evaluateQuietDepth`, which checks if error output should be printed or be delayed (for possible discarding).
