### PR TITLE
Add environment variable for admin in NPM publish workflow

### DIFF
--- a/.github/workflows/NPM-Publish.yml
+++ b/.github/workflows/NPM-Publish.yml
@@ -11,6 +11,7 @@ jobs:
   build-validate:
     name: Pre-Publish Validation
     runs-on: ubuntu-latest
+    environment: admin
 
     steps:
       - name: Download Source Files
@@ -76,5 +77,3 @@ jobs:
 
       - name: Upload Package to NPM Registry
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Require admin environment for publishing, use trusted publishing instead of NPM_KEY.